### PR TITLE
Fix dark-theme and share-button

### DIFF
--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -73,7 +73,11 @@ function Header({ darkMode, setDarkMode }) {
   }
 
   const handleToggleDarkMode = () => {
-    setDarkMode(prevMode => !prevMode)
+    setDarkMode(prevMode => {
+      const newMode = !prevMode
+      localStorage.setItem('darkMode', newMode ? '1' : '0')
+      return newMode
+    })
   }
 
   return (

--- a/frontend/components/ProductGrid.js
+++ b/frontend/components/ProductGrid.js
@@ -69,18 +69,6 @@ export default function ProductGrid(props) {
   }, [])
 
   const columns = React.useMemo(() => {
-    const getDownloadUrl = row => {
-      const { id, /* eslint-disable camelcase */ display_name } = row
-
-      const formattedDisplayName = display_name
-        .replace(/[-\s]/g, '')
-        .toLowerCase()
-
-      const productUrl = getProductUrl(`${id}_${formattedDisplayName}`)
-      const downloadUrl = `${window.location.origin}${productUrl}`
-      return downloadUrl
-    }
-
     const handleDownload = row => {
       router.push(getProductUrl(row.internal_name))
     }
@@ -90,8 +78,9 @@ export default function ProductGrid(props) {
     }
 
     const handleShare = row => {
-      const downloadUrl = getDownloadUrl(row)
-      setSelectedFileUrl(downloadUrl)
+      const productUrl = getProductUrl(row.internal_name)
+      const shareUrl = `${window.location.origin}${productUrl}`
+      setSelectedFileUrl(shareUrl)
       setSnackbarOpen(true)
     }
 

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -22,6 +22,11 @@ export default function MyApp(props) {
     if (jssStyles) {
       jssStyles.parentElement.removeChild(jssStyles)
     }
+
+    const darkModePreference = localStorage.getItem('darkMode')
+    if (darkModePreference) {
+      setDarkMode(darkModePreference === '1')
+    }
   }, [])
 
   const light = createTheme({


### PR DESCRIPTION
persist the last theme chosen by the user. Now when the user chooses a theme, it will be saved in his browser, so that every time he accesses the **PZ-SERVER**, his preferred theme will already be selected.

fixed the way the 'share' function was getting the download url.

To test it out, just pull the '`final-adjustments`' branch in your development environment.