### PR TITLE
Closed #176 was changed official-products title

### DIFF
--- a/frontend/pages/oficial_products.js
+++ b/frontend/pages/oficial_products.js
@@ -32,7 +32,7 @@ export default function Products() {
         <Grid item xs={4}>
           {/* TODO: Aqui deve entrar o BREADCRUMB */}
           <Typography variant="h3" className={classes.title}>
-            LSST PZ Data Products
+            Rubin Observatory PZ Data Products
           </Typography>
         </Grid>
         <Grid item xs={4}>


### PR DESCRIPTION
 Was changed **official-products** title from '_LSST PZ Data Products_' -> '_Rubin Observatory PZ Data Products_'
 
 To perform a test, access the PZ-SERVER and open the Official Data Products card. You'll notice that the title now matches the selected card.