### PR TITLE
Layout adjustment

### DIFF
--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -170,10 +170,19 @@ export default function ProductDetail({ productId, internalName }) {
           <ListItemText
             primary={name}
             secondary={`Main file ${prettyBytes(file.size)}`}
+            primaryTypographyProps={{
+              noWrap: true
+            }}
           />
         )}
         {file.role !== 0 && (
-          <ListItemText primary={name} secondary={prettyBytes(file.size)} />
+          <ListItemText
+            primary={name}
+            secondary={prettyBytes(file.size)}
+            primaryTypographyProps={{
+              noWrap: true
+            }}
+          />
         )}
       </ListItem>
     )

--- a/frontend/pages/product/new.js
+++ b/frontend/pages/product/new.js
@@ -130,7 +130,7 @@ export default function NewProduct() {
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
     },
     {
-      label: 'Association Columns',
+      label: 'Columns Association',
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
     },
@@ -199,11 +199,6 @@ export default function NewProduct() {
               )
             })}
           </Stepper>
-          {/* <Box className={classes.stepDescription}>
-            <Typography variant="body">
-              {steps[activeStep].description}
-            </Typography>
-          </Box> */}
           <Box
             sx={{
               mt: 2,
@@ -213,12 +208,7 @@ export default function NewProduct() {
             // height="400px"
             alignItems="center"
             justifyContent="center"
-            // style={{
-            //   overflow: 'hidden',
-            //   overflowY: 'scroll'
-            // }}
           >
-            {/* {product && steps[activeStep].component(product.id)} */}
             {activeStep === 0 && step1(productId)}
             {activeStep === 1 && step2(productId)}
             {activeStep === 2 && step3(productId)}


### PR DESCRIPTION
Fixed a small bug on the **product details** page where the file name was sticking out of the card on smaller screens.

Then in **Step3**, the name of the label that was inverted was adjusted. Association Columns > Association Columns.