### PR TITLE
Fixes #187 - fixed the error that was occurring when trying to upload

### DIFF
--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -124,9 +124,9 @@ export default function ProductDetail({ productId, internalName }) {
 
         setLoading(false)
       })
-      .catch(res => {
+      .catch(error => {
         setLoading(false)
-        if (res.response.status === 500) {
+        if (error.response && error.response.status === 500) {
           // TODO: Tratar erro
         }
       })

--- a/frontend/components/newProduct/Step4.js
+++ b/frontend/components/newProduct/Step4.js
@@ -20,14 +20,16 @@ export default function NewProductStep4({ productId, onNext, onPrev }) {
           onNext(data.internal_name)
         }
       })
-      .catch(res => {
+      .catch(error => {
         setLoading(false)
-        if (res.response.status === 400) {
+        if (error.response && error.response.status === 400) {
           // Tratamento para erro nos campos
-          catchFormError(res.response.data)
-        }
-        if (res.response.status === 500) {
-          catchFormError(res.response.data)
+          catchFormError(error.response.data)
+        } else if (error.response && error.response.status === 500) {
+          catchFormError(error.response.data)
+        } else {
+          // Tratamento de erro genérico caso a propriedade 'response' não esteja presente
+          console.error('Ocorreu um erro:', error)
         }
       })
   }


### PR DESCRIPTION
Fixed the error that was occurring when trying to upload a .pq file. 

the error was being caused due to trying to access `res.response.status` directly after a `.catch()` without checking if the `response` property exists in the error object.