### PR TITLE
Closes #199 - Now, when loading a file in table preview, a 'Loading...' message will appear.

### DIFF
--- a/frontend/components/ProductDataGrid.js
+++ b/frontend/components/ProductDataGrid.js
@@ -94,7 +94,7 @@ export default function ProductDataGrid(props) {
           disableColumnMenu
           disableColumnSelector
           localeText={{
-            noRowsLabel: isLoading ? 'No rows' : 'Loading...',
+            noRowsLabel: isLoading ? 'No rows' : 'Loading...'
           }}
         />
       )}

--- a/frontend/components/ProductDataGrid.js
+++ b/frontend/components/ProductDataGrid.js
@@ -93,6 +93,9 @@ export default function ProductDataGrid(props) {
           loading={isLoading}
           disableColumnMenu
           disableColumnSelector
+          localeText={{
+            noRowsLabel: isLoading ? 'No rows' : 'Loading...',
+          }}
         />
       )}
     </>


### PR DESCRIPTION
Now, while the `table preview` file is loaded, the message 'Loading...' is displayed instead of 'No rows'