### PR TITLE
Fix! Enhancements in Deletion Functionality

### DIFF
--- a/backend/core/models/product.py
+++ b/backend/core/models/product.py
@@ -65,3 +65,8 @@ class Product(models.Model):
             # raise OSError("Failed to remove directory: [ %s ] %s" % (product_path, e))
 
         super().delete(*args, **kwargs)
+
+    def can_delete(self, user) -> bool:
+        if self.user.id == user.id or user.profile.is_admin():
+            return True
+        return False

--- a/backend/core/serializers/product.py
+++ b/backend/core/serializers/product.py
@@ -1,6 +1,6 @@
+from core.models import Product, ProductType, Release
 from pkg_resources import require
 from rest_framework import serializers
-from core.models import Release, ProductType, Product
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -19,6 +19,8 @@ class ProductSerializer(serializers.ModelSerializer):
     uploaded_by = serializers.SerializerMethodField()
 
     is_owner = serializers.SerializerMethodField()
+
+    can_delete = serializers.SerializerMethodField()
 
     class Meta:
         model = Product
@@ -43,3 +45,7 @@ class ProductSerializer(serializers.ModelSerializer):
             return True
         else:
             return False
+
+    def get_can_delete(self, obj):
+        current_user = self.context["request"].user
+        return obj.can_delete(current_user)

--- a/backend/core/test/test_product.py
+++ b/backend/core/test/test_product.py
@@ -288,6 +288,7 @@ class ProductDetailAPIViewTestCase(APITestCase):
             "product_type_name": self.product_type.display_name,
             "uploaded_by": self.user.username,
             "is_owner": True,
+            "can_delete": True,
             "internal_name": self.product.internal_name,
             "display_name": self.product.display_name,
             "official_product": self.product.official_product,
@@ -330,6 +331,27 @@ class ProductDetailAPIViewTestCase(APITestCase):
         request = factory.delete(self.url, format="json")
         force_authenticate(request, user=self.user, token=self.user.auth_token)
         request.user = self.user
+
+        raw_response = view(request, pk=self.product.pk)
+        response = raw_response.render()
+
+        self.assertEqual(204, response.status_code)
+
+    def test_product_object_delete_by_admin(self):
+        """Tests if the product admin can remove it"""
+        view = ProductViewSet.as_view({"delete": "destroy"})
+
+        # Cria um usuario que faz parte do grupo admin
+        adm_group = Group.objects.create(name="Admin")
+        user = User.objects.create_user("john2", "john2@snow.com", "you_know_nothing")
+        user.groups.add(adm_group)
+        token = Token.objects.create(user=user)
+        # Cria uma requisicao utilizando Factory
+        # para que o metodo destroy da view tenha acesso ao request.user
+        factory = APIRequestFactory()
+        request = factory.delete(self.url, format="json")
+        force_authenticate(request, user=user, token=user.auth_token)
+        request.user = user
 
         raw_response = view(request, pk=self.product.pk)
         response = raw_response.render()

--- a/backend/core/views/product.py
+++ b/backend/core/views/product.py
@@ -379,9 +379,11 @@ class ProductViewSet(viewsets.ModelViewSet):
         return zip_path
 
     def destroy(self, request, pk=None, *args, **kwargs):
-        # TODO: Duvida, Admin pode remover produto que não seja dele?
+        """Produto só pode ser excluido pelo DONO ou se o usuario tiver profile de admin.
+        """
+        # Regra do admin atualizada na issue: #192 - https://github.com/linea-it/pzserver_app/issues/192
         instance = self.get_object()
-        if self.request.user.id == instance.user.pk:
+        if instance.can_delete(self.request.user):
             return super(ProductViewSet, self).destroy(request, pk, *args, **kwargs)
         else:
             raise exceptions.PermissionDenied()

--- a/frontend/components/ProductGrid.js
+++ b/frontend/components/ProductGrid.js
@@ -3,6 +3,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import DownloadIcon from '@mui/icons-material/Download'
 import ShareIcon from '@mui/icons-material/Share'
 import Alert from '@mui/material/Alert'
+import Tooltip from '@mui/material/Tooltip'
 import Link from '@mui/material/Link'
 import Snackbar from '@mui/material/Snackbar'
 import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid'
@@ -158,11 +159,21 @@ export default function ProductGrid(props) {
         width: 120,
         sortable: false,
         renderCell: params => (
-          <GridActionsCellItem
-            icon={<DeleteIcon />}
-            onClick={() => handleDelete(params.row)}
-            disabled={!params.row.can_delete}
-          />
+          <Tooltip
+            title={
+              !params.row.can_delete
+                ? 'You cannot delete this data product because it belongs to another user.'
+                : 'Delete this data product.'
+            }
+          >
+            <div>
+              <GridActionsCellItem
+                icon={<DeleteIcon />}
+                onClick={() => handleDelete(params.row)}
+                disabled={!params.row.can_delete}
+              />
+            </div>
+          </Tooltip>
         )
       }
     ]

--- a/frontend/components/ProductGrid.js
+++ b/frontend/components/ProductGrid.js
@@ -167,6 +167,10 @@ export default function ProductGrid(props) {
     ]
   }, [getProductUrl, router])
 
+  function handleError(errorMessage) {
+    console.error(errorMessage)
+  }
+
   return (
     <React.Fragment>
       <DataGrid
@@ -198,6 +202,7 @@ export default function ProductGrid(props) {
           onClose={() => setDelRecordId(null)}
           recordId={delRecordId}
           onRemoveSuccess={loadProducts}
+          onError={handleError}
         />
       )}
 

--- a/frontend/components/ProductGrid.js
+++ b/frontend/components/ProductGrid.js
@@ -161,6 +161,7 @@ export default function ProductGrid(props) {
           <GridActionsCellItem
             icon={<DeleteIcon />}
             onClick={() => handleDelete(params.row)}
+            disabled={!params.row.can_delete}
           />
         )
       }

--- a/frontend/components/ProductRemove.js
+++ b/frontend/components/ProductRemove.js
@@ -1,14 +1,13 @@
-import LoadingButton from '@mui/lab/LoadingButton'
-import Button from '@mui/material/Button'
+import React from 'react'
+import PropTypes from 'prop-types'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
-import PropTypes from 'prop-types'
-import React from 'react'
+import Button from '@mui/material/Button'
+import LoadingButton from '@mui/lab/LoadingButton'
 import { deleteProduct } from '../services/product'
-
 export default function ProductRemove({
   recordId,
   onRemoveSuccess,
@@ -16,7 +15,6 @@ export default function ProductRemove({
   onError
 }) {
   const [isLoading, setLoading] = React.useState(false)
-  const [isAuthorized, setAuthorized] = React.useState(true)
 
   const handleDelete = async () => {
     setLoading(true)
@@ -25,13 +23,9 @@ export default function ProductRemove({
       onRemoveSuccess()
       onClose()
     } catch (error) {
-      if (error.response && error.response.status === 403) {
-        setAuthorized(false)
-      } else {
-        onError(
-          'Failed to remove the product. Please try again later or contact the helpdesk.'
-        )
-      }
+      onError(
+        'Failed to remove the product. Please try again later or contact the helpdesk.'
+      )
       setLoading(false)
     }
   }
@@ -48,30 +42,14 @@ export default function ProductRemove({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        {isAuthorized && (
-          <LoadingButton
-            loading={isLoading}
-            variant="contained"
-            onClick={handleDelete}
-          >
-            Delete
-          </LoadingButton>
-        )}
+        <LoadingButton
+          loading={isLoading}
+          variant="contained"
+          onClick={handleDelete}
+        >
+          Delete
+        </LoadingButton>
       </DialogActions>
-      {!isAuthorized && (
-        <Dialog open={true}>
-          <DialogContent>
-            <DialogContentText>
-              {
-                'You cannot delete this data product because it belongs to another user.'
-              }
-            </DialogContentText>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={onClose}>Close</Button>
-          </DialogActions>
-        </Dialog>
-      )}
     </Dialog>
   )
 }

--- a/frontend/components/ProductRemove.js
+++ b/frontend/components/ProductRemove.js
@@ -8,6 +8,7 @@ import DialogTitle from '@mui/material/DialogTitle'
 import Button from '@mui/material/Button'
 import LoadingButton from '@mui/lab/LoadingButton'
 import { deleteProduct } from '../services/product'
+
 export default function ProductRemove({
   recordId,
   onRemoveSuccess,
@@ -15,6 +16,7 @@ export default function ProductRemove({
   onError
 }) {
   const [isLoading, setLoading] = React.useState(false)
+  const [isAuthorized, setAuthorized] = React.useState(true)
 
   const handleDelete = async () => {
     setLoading(true)
@@ -23,9 +25,13 @@ export default function ProductRemove({
       onRemoveSuccess()
       onClose()
     } catch (error) {
-      onError(
-        'Failed to remove the product. Please try again later or contact the helpdesk.'
-      )
+      if (error.response && error.response.status === 403) {
+        setAuthorized(false)
+      } else {
+        onError(
+          'Failed to remove the product. Please try again later or contact the helpdesk.'
+        )
+      }
       setLoading(false)
     }
   }
@@ -42,14 +48,30 @@ export default function ProductRemove({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <LoadingButton
-          loading={isLoading}
-          variant="contained"
-          onClick={handleDelete}
-        >
-          Delete
-        </LoadingButton>
+        {isAuthorized ? (
+          <LoadingButton
+            loading={isLoading}
+            variant="contained"
+            onClick={handleDelete}
+          >
+            Delete
+          </LoadingButton>
+        ) : (
+          <Button onClick={onClose}>Close</Button>
+        )}
       </DialogActions>
+      {!isAuthorized && (
+        <Dialog open={true}>
+          <DialogContent>
+            <DialogContentText>
+              {'You cannot delete this data product because it belongs to another user.'}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={onClose}>Close</Button>
+          </DialogActions>
+        </Dialog>
+      )}
     </Dialog>
   )
 }

--- a/frontend/components/ProductRemove.js
+++ b/frontend/components/ProductRemove.js
@@ -1,12 +1,12 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import LoadingButton from '@mui/lab/LoadingButton'
+import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
-import Button from '@mui/material/Button'
-import LoadingButton from '@mui/lab/LoadingButton'
+import PropTypes from 'prop-types'
+import React from 'react'
 import { deleteProduct } from '../services/product'
 
 export default function ProductRemove({
@@ -48,7 +48,7 @@ export default function ProductRemove({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        {isAuthorized ? (
+        {isAuthorized && (
           <LoadingButton
             loading={isLoading}
             variant="contained"
@@ -56,15 +56,15 @@ export default function ProductRemove({
           >
             Delete
           </LoadingButton>
-        ) : (
-          <Button onClick={onClose}>Close</Button>
         )}
       </DialogActions>
       {!isAuthorized && (
         <Dialog open={true}>
           <DialogContent>
             <DialogContentText>
-              {'You cannot delete this data product because it belongs to another user.'}
+              {
+                'You cannot delete this data product because it belongs to another user.'
+              }
             </DialogContentText>
           </DialogContent>
           <DialogActions>


### PR DESCRIPTION
1. Users with common privileges can now only delete their own records, while administrators retain the ability to delete any record. The DeleteIcon is intelligently disabled for products owned by other users, while it remains active for administrators.

2. Was added an informative hover message to the DeleteIcon. Now, when you hover your mouse over the icon, you'll receive context-aware feedback:

- If you're the owner of the record, you'll receive a positive message.
- If the record doesn't belong to you, you'll receive a negative message.

[Here is a short video demonstrating the features of this update.](https://youtu.be/AzBGGfZzNdI)