### PR TITLE
Closes #212 - The new 'STATUS' column was implemented in Data Products

### DIFF
--- a/frontend/components/ProductGrid.js
+++ b/frontend/components/ProductGrid.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types'
 import * as React from 'react'
 import { getProducts } from '../services/product'
 
+import ProductStatus from './ProductStatus.js'
 import ProductRemove from '../components/ProductRemove'
 import ProductShare from './ProductShare'
 
@@ -133,6 +134,15 @@ export default function ProductGrid(props) {
           }
           return moment(params.value).format('YYYY-MM-DD')
         }
+      },
+      {
+        field: 'status',
+        headerName: 'Status',
+        flex: 1,
+        sortable: false,
+        renderCell: params => (
+          <ProductStatus value={parseInt(params.row.status)} />
+        )
       },
       {
         field: 'actions_download',

--- a/frontend/components/ProductStatus.js
+++ b/frontend/components/ProductStatus.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Typography from '@mui/material/Typography'
+
+const statusLabels = {
+  0: 'Registering',
+  1: 'Published',
+  9: 'Failed'
+}
+
+export default function ProductStatus({ value }) {
+  const statusLabel = statusLabels[value] || 'Unknown'
+
+  return <Typography>{statusLabel}</Typography>
+}
+
+ProductStatus.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired
+}


### PR DESCRIPTION
**News in Data Products:**

Added "Status" column to the dataset in Data Products to reflect the current state of each product. The "Status" column now displays crucial information about the product's progress. The possible values and their meanings are as follows:

- **0: 'Registering'**: Indicates that the product is in the registration process.
- **1: 'Published'**: Signals that the product was published successfully.
- **9: 'Failed'**: Indicates that a failure occurred during the process.

![image](https://github.com/linea-it/pzserver_app/assets/101944851/b254f152-a892-474d-8650-aba1ccf4e686)
