### PR TITLE
feat: add tooltip to display_name showing product description

### DIFF
--- a/frontend/components/ProductGrid.js
+++ b/frontend/components/ProductGrid.js
@@ -3,10 +3,10 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import DownloadIcon from '@mui/icons-material/Download'
 import EditIcon from '@mui/icons-material/Edit'
 import ShareIcon from '@mui/icons-material/Share'
+import { Box } from '@mui/material'
 import Alert from '@mui/material/Alert'
 import Link from '@mui/material/Link'
 import Snackbar from '@mui/material/Snackbar'
-import { Box } from '@mui/material'
 import Tooltip from '@mui/material/Tooltip'
 import { DataGrid, GridActionsCellItem } from '@mui/x-data-grid'
 import moment from 'moment'
@@ -101,9 +101,11 @@ export default function ProductGrid(props) {
         flex: 1,
         minWidth: 150,
         renderCell: params => (
-          <Link component="button" onClick={() => handleDownload(params.row)}>
-            {params.value}
-          </Link>
+          <Tooltip title={params.row.description || 'No description available'}>
+            <Link component="button" onClick={() => handleDownload(params.row)}>
+              {params.value}
+            </Link>
+          </Tooltip>
         )
       },
       {


### PR DESCRIPTION
Now, when hovering over the product name, the product description will appear. If there is no description available, a message will display indicating that no description is provided.

![description](https://github.com/user-attachments/assets/0cacbc22-7bd0-40b5-b12f-4f543d36c4de)
