### PR TITLE
Omit Table Preview for Non-Tabular Data Types

### DIFF
--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -57,6 +57,7 @@ export default function ProductDetail({ productId, internalName }) {
 
   const [activeTab, setActiveTab] = React.useState(0)
   const [hasHtmlFile, setHasHtmlFile] = React.useState(false)
+  const [isTabular, setIsTabular] = React.useState(false)
 
   const loadProductById = React.useCallback(async () => {
     setLoading(true)
@@ -131,6 +132,18 @@ export default function ProductDetail({ productId, internalName }) {
         setHasHtmlFile(hasHtmlFile)
 
         setActiveTab(hasHtmlFile ? 1 : 0)
+
+        const isTabularData = res.results.some(file => {
+          const lowerName = file.name.toLowerCase()
+          return (
+            lowerName.endsWith('.csv') ||
+            lowerName.endsWith('.xls') ||
+            lowerName.endsWith('.xlsx') ||
+            lowerName.endsWith('.pq') ||
+            lowerName.endsWith('.parquet')
+          )
+        })
+        setIsTabular(isTabularData)
 
         setLoading(false)
 
@@ -349,38 +362,42 @@ export default function ProductDetail({ productId, internalName }) {
               </Stack>
             </Paper>
           </Grid>
-          <Grid item xs={12}>
-            <Card elevation={2}>
-              <CardContent>
-                <Tabs
-                  value={activeTab}
-                  onChange={(event, newValue) => setActiveTab(newValue)}
-                >
-                  {hasHtmlFile && <Tab label="Description File" value={1} />}
-                  <Tab label="Table Preview" value={0} />
-                </Tabs>
-                {activeTab === 0 && <ProductDataGrid productId={product.id} />}
-                {activeTab === 1 && hasHtmlFile && (
-                  <div>
-                    {files.map(file => {
-                      if (file.name.toLowerCase().endsWith('.html')) {
-                        return (
-                          <CardMedia
-                            component="iframe"
-                            src={file.file}
-                            height="800"
-                            key={file.id}
-                            sx={{ border: 'none' }}
-                          />
-                        )
-                      }
-                      return null
-                    })}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </Grid>
+          {isTabular && (
+            <Grid item xs={12}>
+              <Card elevation={2}>
+                <CardContent>
+                  <Tabs
+                    value={activeTab}
+                    onChange={(event, newValue) => setActiveTab(newValue)}
+                  >
+                    {hasHtmlFile && <Tab label="Description File" value={1} />}
+                    <Tab label="Table Preview" value={0} />
+                  </Tabs>
+                  {activeTab === 0 && (
+                    <ProductDataGrid productId={product.id} />
+                  )}
+                  {activeTab === 1 && hasHtmlFile && (
+                    <Box>
+                      {files.map(file => {
+                        if (file.name.toLowerCase().endsWith('.html')) {
+                          return (
+                            <CardMedia
+                              component="iframe"
+                              src={file.file}
+                              height="800"
+                              key={file.id}
+                              sx={{ border: 'none' }}
+                            />
+                          )
+                        }
+                        return null
+                      })}
+                    </Box>
+                  )}
+                </CardContent>
+              </Card>
+            </Grid>
+          )}
         </Grid>
       </Box>
     </React.Fragment>

--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -139,7 +139,15 @@ export default function ProductDetail({ productId, internalName }) {
             lowerName.endsWith('.csv') ||
             lowerName.endsWith('.xls') ||
             lowerName.endsWith('.xlsx') ||
+            lowerName.endsWith('.txt') ||
+            lowerName.endsWith('.fit') ||
+            lowerName.endsWith('.fits') ||
+            lowerName.endsWith('.h5') ||
+            lowerName.endsWith('.hf5') ||
+            lowerName.endsWith('.hdf') ||
+            lowerName.endsWith('.hdf5') ||
             lowerName.endsWith('.pq') ||
+            lowerName.endsWith('.parq') ||
             lowerName.endsWith('.parquet')
           )
         })


### PR DESCRIPTION
### Summary
This PR addresses the issue of table previews being displayed for non-tabular data types such as .pkl, .pickle, and .tar files. Previously, these files would show an error message in the table preview card. This change ensures that the entire table preview card is hidden for non-tabular data types, improving the user experience.

### Changes
- Added logic to identify tabular data types, including .csv, .xls, .xlsx, .pq, and .parquet files.
- Modified the `ProductDetail` component to conditionally render the table preview card based on the data type.
- Updated the `loadFiles` function to set the `isTabular` state based on the file types.

### Testing
- Verified that table previews are displayed correctly for tabular data types.
- Ensured that the table preview card is hidden for non-tabular data types.
- Tested with various file formats to confirm the expected behavior.