### PR TITLE
Fixes: Warnings invalid pro types

### DIFF
--- a/frontend/pages/specz_catalogs.js
+++ b/frontend/pages/specz_catalogs.js
@@ -33,7 +33,7 @@ function SpeczCatalogs() {
   const [combinedCatalogName, setCombinedCatalogName] = useState('')
   const [search, setSearch] = useState('')
   const router = useRouter()
-  const filters = useState()
+  const [filters] = useState({})
   const [snackbarOpen, setSnackbarOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
@@ -46,7 +46,7 @@ function SpeczCatalogs() {
     }
   })
   const [data, setData] = useState(initialData)
-  const fieldErrors = useState({})
+  const [fieldErrors] = useState({})
   const [selectedProducts, setSelectedProducts] = useState([])
 
   useEffect(() => {
@@ -68,6 +68,7 @@ function SpeczCatalogs() {
     setCombinedCatalogName('')
     setSelectedProducts([])
   }
+
   const handleSnackbarClose = () => {
     setSnackbarOpen(false)
     setIsSubmitting(false)


### PR DESCRIPTION
#### Description
Summary:
This pull request fixes the prop type validation warning for the `filters` prop in the `DataTableWrapper` component by ensuring that `filters` is always passed as an object.

#### Changes:

- Initialized `filters` as an object using `useState({}`) in `SpeczCatalogs.js`.
- Updated the usage of` DataTableWrapper` to pass `filters` as an object.