### PR TITLE
Number of rows on product details

### DIFF
--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -208,7 +208,13 @@ export default function ProductDetail({ productId, internalName }) {
         {file.role === 0 && (
           <ListItemText
             primary={name}
-            secondary={`Main file ${prettyBytes(file.size)}`}
+            secondary={
+              <>
+                Main file {prettyBytes(file.size)}
+                <br />
+                Total of rows: {file.n_rows ? file.n_rows : 'undefined'}
+              </>
+            }
             primaryTypographyProps={{
               noWrap: true
             }}


### PR DESCRIPTION
in products with tabular main file:
![image](https://github.com/user-attachments/assets/c98f08b0-25e9-4f3d-8805-8c7d39226539)

in cases where the main file is not tabular, like a .pkl for example:
![image](https://github.com/user-attachments/assets/c8a8e4f8-96b4-414b-a5dc-600afd507722)
