### PR TITLE
feat: add output format selection to SpeczCatalogs and TrainingSetMaker components

### DIFF
--- a/frontend/pages/specz_catalogs.js
+++ b/frontend/pages/specz_catalogs.js
@@ -17,6 +17,8 @@ import Link from '@mui/material/Link'
 import Paper from '@mui/material/Paper'
 import Snackbar from '@mui/material/Snackbar'
 import SnackbarContent from '@mui/material/SnackbarContent'
+import Select from '@mui/material/Select'
+import MenuItem from '@mui/material/MenuItem'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import { useTheme } from '@mui/system'
@@ -48,6 +50,7 @@ function SpeczCatalogs() {
   const [data, setData] = useState(initialData)
   const [fieldErrors] = useState({})
   const [selectedProducts, setSelectedProducts] = useState([])
+  const [outputFormat, setOutputFormat] = useState('parquet')
 
   useEffect(() => {
     const fetchPipelineData = async () => {
@@ -67,6 +70,7 @@ function SpeczCatalogs() {
   const handleClearForm = () => {
     setCombinedCatalogName('')
     setSelectedProducts([])
+    setOutputFormat('parquet')
   }
 
   const handleSnackbarClose = () => {
@@ -119,7 +123,8 @@ function SpeczCatalogs() {
           }
         },
         description: data.param.description,
-        inputs: selectedProducts.map(product => product.id)
+        inputs: selectedProducts.map(product => product.id),
+        output_format: outputFormat
       }
 
       // tentativa de envio do json via POST
@@ -152,6 +157,10 @@ function SpeczCatalogs() {
 
   const handleProductSelection = selectedProducts => {
     setSelectedProducts(selectedProducts)
+  }
+
+  const handleOutputFormatChange = event => {
+    setOutputFormat(event.target.value)
   }
 
   const styles = {
@@ -256,6 +265,21 @@ function SpeczCatalogs() {
                 />
               </CardContent>
             </Card>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Typography variant="body1">
+              4. Output format:
+              <Select value={outputFormat} onChange={handleOutputFormatChange}>
+                <MenuItem value="parquet">parquet</MenuItem>
+                <MenuItem value="csv">csv</MenuItem>
+                <MenuItem value="fits">fits</MenuItem>
+                <MenuItem value="hdf5">hdf5</MenuItem>
+                <MenuItem value="votable" disabled>
+                  VOTable
+                </MenuItem>
+              </Select>
+            </Typography>
           </Grid>
 
           <Grid item xs={12}>

--- a/frontend/pages/training_set_maker.js
+++ b/frontend/pages/training_set_maker.js
@@ -46,6 +46,7 @@ function TrainingSetMaker() {
   const [selectedLsstCatalog, setSelectedLsstCatalog] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [releases, setReleases] = useState([])
+  const [outputFormat, setOutputFormat] = useState('specz')
   const [initialData, setInitialData] = useState({
     param: {
       crossmatch: {
@@ -99,6 +100,7 @@ function TrainingSetMaker() {
     setCombinedCatalogName('')
     setData(initialData.system_config)
     setSelectedLsstCatalog('')
+    setOutputFormat('specz')
     setIsSubmitting(false)
   }
 
@@ -154,6 +156,7 @@ function TrainingSetMaker() {
             duplicate_criteria: data.param.duplicate_criteria
           }
         },
+        output_format: outputFormat,
         release: releaseId,
         description: data.param.description,
         inputs: [selectedProductId]
@@ -304,7 +307,27 @@ function TrainingSetMaker() {
 
           <Grid item xs={12}>
             <Typography variant="body1">
-              4. Select the Objects catalog (photometric data):
+              4. Output format:
+              <Select
+                value={outputFormat}
+                onChange={event => setOutputFormat(event.target.value)}
+                defaultValue="specz"
+              >
+                <MenuItem value="specz">same as spec-z catalog</MenuItem>
+                <MenuItem value="csv">csv</MenuItem>
+                <MenuItem value="fits">fits</MenuItem>
+                <MenuItem value="parquet">parquet</MenuItem>
+                <MenuItem value="hdf5">hdf5</MenuItem>
+                <MenuItem value="votable" disabled>
+                  VOTable
+                </MenuItem>
+              </Select>
+            </Typography>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Typography variant="body1">
+              5. Select the Objects catalog (photometric data):
               <Select
                 value={selectedLsstCatalog}
                 onChange={event => setSelectedLsstCatalog(event.target.value)}
@@ -321,7 +344,7 @@ function TrainingSetMaker() {
 
           <Grid item xs={12} mt={3}>
             <Typography variant="body1">
-              5. Select the cross-matching configuration choices:
+              6. Select the cross-matching configuration choices:
             </Typography>
             <Grid item xs={12} mt={2}>
               <Box display="flex" alignItems="center" ml={4}>


### PR DESCRIPTION
### Adds the option to select the output format in the `SpeczCatalogs` and `TrainingSetMaker` components.

#### Default Formats
- `SpeczCatalogs`: parquet
- `TrainingSetMaker`: specz

#### examples
- CSC
![image](https://github.com/user-attachments/assets/f2e6468a-f1b9-4943-bff0-e6431602d8b2)


- TSM
![image](https://github.com/user-attachments/assets/6a8f0547-ae61-476d-9c60-ad59359b1b5a)
