### PR TITLE
feat: implement file deletion authorization for product files.

### DIFF
--- a/backend/core/models/product_file.py
+++ b/backend/core/models/product_file.py
@@ -45,5 +45,10 @@ class ProductFile(models.Model):
             self.file.delete()
         super().delete(*args, **kwargs)
 
+    def can_delete(self, user) -> bool:
+        if self.product.user.id == user.id or user.profile.is_admin():
+            return True
+        return False
+
     def __str__(self):
         return f"{self.product.display_name} - {os.path.basename(self.file.name)}"

--- a/backend/core/serializers/product_file.py
+++ b/backend/core/serializers/product_file.py
@@ -10,6 +10,8 @@ class ProductFileSerializer(serializers.ModelSerializer):
 
     file = serializers.FileField()
 
+    can_delete = serializers.SerializerMethodField()
+
     class Meta:
         model = ProductFile
         read_only_fields = (
@@ -19,3 +21,7 @@ class ProductFileSerializer(serializers.ModelSerializer):
             "extension",
         )
         fields = "__all__"
+
+    def get_can_delete(self, obj):
+        current_user = self.context["request"].user
+        return obj.can_delete(current_user)


### PR DESCRIPTION
This commit introduces authorization checks for deleting product files.

- Only the owner of the product or an admin user can delete a product file.
- Added a `can_delete` method to the `ProductFile` model to determine if a user has permission to delete the file.
- Implemented permission checks in the `ProductFileViewSet`'s `destroy` method.
- Added `can_delete` field to `ProductFileSerializer` to expose the permission status to the frontend.
- Updated the `create` method in `ProductFileViewSet` to only allow the product owner to create product files.