### PR TITLE
feat: configure task-specific logging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,15 +23,15 @@
 			"nodeGypDependencies": true,
 			"version": "lts"
 		},
-		"ghcr.io/devcontainers-contrib/features/black:2": {
-			"version": "latest"
-		},
-		"ghcr.io/devcontainers-contrib/features/isort:2": {
-			"version": "latest"
-		},
-		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {
-			"version": "latest"
-		},
+		// "ghcr.io/devcontainers-contrib/features/black:2": {
+		// 	"version": "latest"
+		// },
+		// "ghcr.io/devcontainers-contrib/features/isort:2": {
+		// 	"version": "latest"
+		// },
+		// "ghcr.io/devcontainers-contrib/features/pre-commit:2": {
+		// 	"version": "latest"
+		// },
 		"ghcr.io/dhoeric/features/act:1": {}
 	},
 	"customizations": {

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -10,7 +10,7 @@ from core.utils import get_ucd_columns, load_yaml
 from django.conf import settings
 from django.utils import dateparse, timezone
 
-LOGGER = logging.getLogger()
+LOGGER = logging.getLogger("tasks")
 
 
 @shared_task()
@@ -22,8 +22,8 @@ def check_processes():
         bool: True, if an update was made. False, if no update was made.
     """
 
+    # LOGGER.debug(f"Monitoring the following statuses: {monitoring_statuses}")
     monitoring_statuses = ["Stopping", "Pending", "Running", "Queued"]
-    LOGGER.debug(f"Monitoring the following statuses: {monitoring_statuses}")
 
     processes = Process.objects.filter(status__in=monitoring_statuses)
 

--- a/backend/pzserver/settings.py
+++ b/backend/pzserver/settings.py
@@ -277,6 +277,14 @@ LOGGING = {
             "backupCount": 5,
             "formatter": "standard",
         },
+        "tasks": {
+            "level": LOGGING_LEVEL,
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": os.path.join(LOG_DIR, "tasks.log"),
+            "maxBytes": 1024 * 1024 * 5,  # 5 MB
+            "backupCount": 5,
+            "formatter": "standard",
+        },
     },
     "loggers": {
         "django": {
@@ -301,6 +309,11 @@ LOGGING = {
         },
         "products": {
             "handlers": ["products"],
+            "level": LOGGING_LEVEL,
+            "propagate": True,
+        },
+        "tasks": {
+            "handlers": ["tasks"],
             "level": LOGGING_LEVEL,
             "propagate": True,
         },


### PR DESCRIPTION
This commit configures a separate logger for Celery tasks.

- Added a `tasks` logger configuration to `settings.py`, directing logs to a dedicated `tasks.log` file.
- Configured the `tasks` logger to use a rotating file handler with a maximum size of 5MB and 5 backup files.
- Updated the `check_processes` task in `core/tasks.py` to use the `tasks` logger.
- Commented out the devcontainer pre-commit hooks.