### PR TITLE
feat: enhance training set maker with flux options and release-specif…

### DIFF
--- a/backend/core/fixtures/initial_data.yaml
+++ b/backend/core/fixtures/initial_data.yaml
@@ -1,7 +1,7 @@
 - model: core.release
   pk: 1
   fields:
-    name: mini_dataset
+    name: dr2
     display_name: Small Dataset
     description: Small dataset for example runs
     created_at: 2022-05-18 15:36:16.234786+00:00
@@ -83,7 +83,7 @@
           memory_limit: "1GiB"
       inputs:
         dataset:
-          path: "/datasets/data-example/mini_dataset"
+          path: "/datasets/data-example/dr2"
           columns:
             id: "id"
         specz:
@@ -94,6 +94,9 @@
       output_dir: "outputs"
       param:
         duplicate_criteria: "closest"
+        flux_type: "auto"
+        convert_flux_to_mag: false
+        dereddening: "sfd"
         crossmatch:
           output_catalog_name: "tsm_cross_001"
           radius_arcsec: 1.0

--- a/frontend/pages/training_set_maker.js
+++ b/frontend/pages/training_set_maker.js
@@ -39,6 +39,7 @@ function TrainingSetMaker() {
   const router = useRouter()
   const [uniqueGalaxies, setUniqueGalaxies] = useState(false)
   const [convertFluxToMag, setConvertFluxToMag] = useState(true)
+  const [disabledFluxToMag, setDisabledConvertFluxToMag] = useState(false)
   const [combinedCatalogName, setCombinedCatalogName] = useState('')
   const [search, setSearch] = useState('')
   const [selectedProductId, setSelectedProductId] = useState(null)
@@ -133,6 +134,13 @@ function TrainingSetMaker() {
         { name: 'gaapPsf', display_name: 'gaapPsf', disabled: true },
         { name: 'psf', display_name: 'psf', disabled: true }
       ]
+    }
+
+    if (releaseName === 'dr2') {
+      setDisabledConvertFluxToMag(true)
+      setConvertFluxToMag(true)
+    } else {
+      setDisabledConvertFluxToMag(false)
     }
 
     if (releaseName in fluxByRelease) {
@@ -550,6 +558,7 @@ function TrainingSetMaker() {
                   <Checkbox
                     checked={convertFluxToMag}
                     onChange={handleConvertFluxToMag}
+                    disabled={!!disabledFluxToMag}
                     inputProps={{ 'aria-label': 'controlled' }}
                   />
                 </Typography>

--- a/frontend/pages/training_set_maker.js
+++ b/frontend/pages/training_set_maker.js
@@ -61,7 +61,7 @@ function TrainingSetMaker() {
       duplicate_criteria: 'closest',
       flux_type: 'cmodel',
       dereddening: 'sfd',
-      convert_flux_to_mag: true,
+      convert_flux_to_mag: true
     }
   })
   const [data, setData] = useState(initialData)
@@ -83,7 +83,7 @@ function TrainingSetMaker() {
     const fetchReleases = async () => {
       try {
         const releasesData = await getReleases()
-    
+
         if (Array.isArray(releasesData.results)) {
           const fetchedReleases = releasesData.results
           setReleases(fetchedReleases)
@@ -111,36 +111,35 @@ function TrainingSetMaker() {
     setIsSubmitting(false)
   }
 
-  const handleRelease = release_name => {
-
-    setSelectedLsstCatalog(release_name)
+  const handleRelease = releaseName => {
+    setSelectedLsstCatalog(releaseName)
 
     const fluxByRelease = {
-      "dr2": [
-        {"name": "auto", "display_name": "auto", "selected": true},
-        {"name": "wavg_psf", "display_name": "wavg_psf", "disabled": true}
+      dr2: [
+        { name: 'auto', display_name: 'auto', selected: true },
+        { name: 'wavg_psf', display_name: 'wavg_psf', disabled: true }
       ],
-      "dp02": [
-        {"name": "cmodel", "display_name": "cModel", "selected": true},
-        {"name": "gaap1p0", "display_name": "gaap1p0"},
-        {"name": "free_cModel", "display_name": "free_cModel", "disabled": true},
-        {"name": "free_psf", "display_name": "free_psf", "disabled": true},
-        {"name": "gaap0p5", "display_name": "gaap0p5", "disabled": true},
-        {"name": "gaap0p7", "display_name": "gaap0p7", "disabled": true},
-        {"name": "gaap1p5", "display_name": "gaap1p5", "disabled": true},
-        {"name": "gaap2p5", "display_name": "gaap2p5", "disabled": true},
-        {"name": "gaap3p0", "display_name": "gaap3p0", "disabled": true},
-        {"name": "aapOptimal", "display_name": "aapOptimal", "disabled": true},
-        {"name": "gaapPsf", "display_name": "gaapPsf", "disabled": true},
-        {"name": "psf", "display_name": "psf", "disabled": true}
-      ],
+      dp02: [
+        { name: 'cmodel', display_name: 'cModel', selected: true },
+        { name: 'gaap1p0', display_name: 'gaap1p0' },
+        { name: 'free_cModel', display_name: 'free_cModel', disabled: true },
+        { name: 'free_psf', display_name: 'free_psf', disabled: true },
+        { name: 'gaap0p5', display_name: 'gaap0p5', disabled: true },
+        { name: 'gaap0p7', display_name: 'gaap0p7', disabled: true },
+        { name: 'gaap1p5', display_name: 'gaap1p5', disabled: true },
+        { name: 'gaap2p5', display_name: 'gaap2p5', disabled: true },
+        { name: 'gaap3p0', display_name: 'gaap3p0', disabled: true },
+        { name: 'aapOptimal', display_name: 'aapOptimal', disabled: true },
+        { name: 'gaapPsf', display_name: 'gaapPsf', disabled: true },
+        { name: 'psf', display_name: 'psf', disabled: true }
+      ]
     }
 
-    if (release_name in fluxByRelease) {
-      const flux_release = fluxByRelease[release_name]
-      setFluxes(flux_release)
+    if (releaseName in fluxByRelease) {
+      const fluxRelease = fluxByRelease[releaseName]
+      setFluxes(fluxRelease)
 
-      flux_release.forEach(flux => {
+      fluxRelease.forEach(flux => {
         if (flux.selected) {
           setData({
             ...data,
@@ -152,7 +151,7 @@ function TrainingSetMaker() {
         }
       })
     }
-  } 
+  }
 
   const handleDialogClose = () => {
     setOpenDialog(false)
@@ -400,10 +399,15 @@ function TrainingSetMaker() {
                       })
                     }}
                     sx={{ marginLeft: '16px' }}
-                  >                
+                  >
                     {fluxes.map(flux => (
-                      <MenuItem value={flux.name} selected={flux.selected ? true : false} disabled={flux.disabled ? true : false}>
-                        {flux.display_name} 
+                      <MenuItem
+                        key={flux.name}
+                        value={flux.name}
+                        selected={!!flux.selected}
+                        disabled={!!flux.disabled}
+                      >
+                        {flux.display_name}
                       </MenuItem>
                     ))}
                   </Select>

--- a/orchestration/datasets/.gitignore
+++ b/orchestration/datasets/.gitignore
@@ -1,4 +1,4 @@
 *
 */
 !.gitignore
-!mini_dataset
+!dr2

--- a/orchestration/datasets/dr2
+++ b/orchestration/datasets/dr2
@@ -1,0 +1,1 @@
+../pipelines/data-example/dr2

--- a/orchestration/datasets/mini_dataset
+++ b/orchestration/datasets/mini_dataset
@@ -1,1 +1,0 @@
-../pipelines/data-example/mini_dataset


### PR DESCRIPTION
…ic configurations

This commit enhances the Training Set Maker tool with flux selection and release-specific configurations.

- Adds flux type selection based on the selected LSST release in `frontend/pages/training_set_maker.js`. Different releases now offer different flux options.
- Introduces a `convert_flux_to_mag` option, allowing users to convert fluxes to magnitudes during training set creation.
- Updates the UI to include a flux type dropdown and a checkbox for converting fluxes to magnitudes.
- Modifies the data submission process to include the selected flux type and the `convert_flux_to_mag` setting.
- Updates the `orchestration/pipelines` submodule.
- Removes the `mini_dataset` symlink.