### PR TITLE
feat: handle non-tabular products and fix tutorial button location

### DIFF
--- a/backend/core/product_steps.py
+++ b/backend/core/product_steps.py
@@ -210,21 +210,26 @@ class RegistryProduct:
             LOGGER.debug("Main File: [%s]" % self.main_file)
 
             product_columns = list()
-            try:
-                # Le o arquivo principal e converte para pandas.Dataframe
-                df_product = ProductHandle().df_from_file(self.main_file)
+            if self.product.product_type.name not in (
+                "other",
+                "photoz_estimates",
+                "validation_results",
+            ):
+                try:
+                    # Le o arquivo principal e converte para pandas.Dataframe
+                    df_product = ProductHandle().df_from_file(self.main_file)
 
-                # Lista de Colunas no arquivo.
-                product_columns = df_product.columns.tolist()
+                    # Lista de Colunas no arquivo.
+                    product_columns = df_product.columns.tolist()
 
-                # Record number of lines of the main product
-                mf.n_rows = len(df_product)
-                mf.save()
-                LOGGER.debug(f"Number of rows: {str(mf.n_rows)}")
-            except NotTableError as err:
-                LOGGER.warning(err)
-                # Acontece com arquivos comprimidos .zip etc.
-                pass
+                    # Record number of lines of the main product
+                    mf.n_rows = len(df_product)
+                    mf.save()
+                    LOGGER.debug(f"Number of rows: {str(mf.n_rows)}")
+                except NotTableError as err:
+                    LOGGER.warning(err)
+                    # Acontece com arquivos comprimidos .zip etc.
+                    pass
 
             # Verifica se o product type é redshift_catalog
             # Para esses produtos é mandatório ter acesso as colunas da tabela

--- a/backend/core/serializers/product.py
+++ b/backend/core/serializers/product.py
@@ -16,6 +16,8 @@ class ProductSerializer(serializers.ModelSerializer):
     )
     product_type_name = serializers.SerializerMethodField()
 
+    product_type_internal_name = serializers.SerializerMethodField()
+
     uploaded_by = serializers.SerializerMethodField()
 
     is_owner = serializers.SerializerMethodField()
@@ -32,11 +34,20 @@ class ProductSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Product
-        read_only_fields = ("internal_name", "is_owner", "origin", "process_status", "product_status")
+        read_only_fields = (
+            "internal_name",
+            "is_owner",
+            "origin",
+            "process_status",
+            "product_status",
+        )
         exclude = ["user", "path"]
 
     def get_product_type_name(self, obj):
         return obj.product_type.display_name
+
+    def get_product_type_internal_name(self, obj):
+        return obj.product_type.name
 
     def get_release_name(self, obj):
         try:
@@ -55,11 +66,11 @@ class ProductSerializer(serializers.ModelSerializer):
             return False
 
     def get_origin(self, obj):
-        return obj.upload.pipeline.display_name if hasattr(obj, 'upload') else "Upload"
-    
+        return obj.upload.pipeline.display_name if hasattr(obj, "upload") else "Upload"
+
     def get_process_status(self, obj):
-        return obj.upload.status if hasattr(obj, 'upload') else None
-    
+        return obj.upload.status if hasattr(obj, "upload") else None
+
     def get_product_status(self, obj):
         pr = ProductStatus(obj.status)
         return pr.label
@@ -70,4 +81,4 @@ class ProductSerializer(serializers.ModelSerializer):
 
     def get_can_update(self, obj):
         current_user = self.context["request"].user
-        return obj.can_update(current_user)    
+        return obj.can_update(current_user)

--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -150,6 +150,7 @@ export default function ProductDetail({ productId, internalName }) {
     if (!product.id) {
       return
     }
+
     setLoading(true)
 
     getProductFiles(product.id)
@@ -181,6 +182,14 @@ export default function ProductDetail({ productId, internalName }) {
             lowerName.endsWith('.parquet')
           )
         })
+
+        if (["other", "photoz_estimates", "validation_results"].includes(product.product_type_internal_name)) {
+          // If the product type is 'other', 'photoz_estimates', or 'validation_results' we don't load files
+          console.log('product.product_type_internal_name', product.product_type_internal_name)
+          setIsTabular(false)
+          return
+        }
+
         setIsTabular(isTabularData)
 
         setLoading(false)

--- a/frontend/pages/tutorials.js
+++ b/frontend/pages/tutorials.js
@@ -47,7 +47,7 @@ export default function Tutorials() {
               <Typography variant="body1" component="span">
                 <p>
                   To upload a data product, click on the button{' '}
-                  <strong>&quot;NEW PRODUCT&quot;</strong> on the top left of
+                  <strong>&quot;NEW PRODUCT&quot;</strong> on the top right of
                   the <strong>&quot;User-generated Data Products&quot;</strong>{' '}
                   page and fill in the Upload Form with relevant metadata.
                 </p>


### PR DESCRIPTION
This commit introduces changes to handle products that are not tabular and fixes the location of the "NEW PRODUCT" button in the tutorials page.

- In `backend/core/serializers/product.py`, a new serializer method `get_product_type_internal_name` is added to expose the internal name of the product type.
- In `backend/core/product_steps.py`, the code that reads the main file and converts it to a Pandas DataFrame is now skipped for product types "other", "photoz_estimates", and "validation_results". This prevents errors when processing non-tabular data.
- In `frontend/components/ProductDetail.js`, the component now checks the `product_type_internal_name`. If it is "other", "photoz_estimates", or "validation_results", the tabular data loading is skipped, and the `isTabular` state is set to false.
- In `frontend/pages/tutorials.js`, the location of the "NEW PRODUCT" button is corrected from the top left to the top right of the "User-generated Data Products" page.