### PR TITLE
feat: update login button labels

### DIFF
--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -174,7 +174,7 @@ function Login({ shibLoginUrl, CILogonUrl, GithubUrl }) {
                     href={GithubUrl || shibLoginUrl}
                     sx={{ bottom: 20 }}
                   >
-                    LOGIN ADMIN 
+                    LOGIN ADMIN
                   </GitHubButton>
                 </Grid>
               </>

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -163,7 +163,7 @@ function Login({ shibLoginUrl, CILogonUrl, GithubUrl }) {
                       }
                     }}
                   >
-                    LOGIN WITH CILOGON (RSP ACCOUNT)
+                    LOGIN LSST MEMBERS (RSP ACCOUNT)
                   </Button>
                 </Grid>
                 <Grid item xs={12}>
@@ -174,7 +174,7 @@ function Login({ shibLoginUrl, CILogonUrl, GithubUrl }) {
                     href={GithubUrl || shibLoginUrl}
                     sx={{ bottom: 20 }}
                   >
-                    Login with GitHub
+                    LOGIN ADMIN 
                   </GitHubButton>
                 </Grid>
               </>


### PR DESCRIPTION
This commit updates the labels of the login buttons on the login page for clarity and to better reflect their intended purpose.

- The "LOGIN WITH CILOGON (RSP ACCOUNT)" button is updated to "LOGIN LSST MEMBERS (RSP ACCOUNT)".
- The "Login with GitHub" button is updated to "LOGIN ADMIN".