### PR TITLE
feat: enable links and update text in TrainingSetMaker and SpeczCatalogs

### DIFF
--- a/frontend/components/SpeczCatalogs.js
+++ b/frontend/components/SpeczCatalogs.js
@@ -22,9 +22,7 @@ function SpeczCatalogs() {
         />
         <Box>
           <CardContent m={2} sx={{ maxWidth: 500 }}>
-            <Typography variant="h5">
-              Combine Redshift Catalogs
-            </Typography>
+            <Typography variant="h5">Combine Redshift Catalogs</Typography>
             <Typography variant="body1" sx={{ mt: 1 }}>
               Creates a single redshift sample from the multiple spatial
               cross-matching (all-to-all) of a list of pre-registered individual

--- a/frontend/components/TrainingSetMaker.js
+++ b/frontend/components/TrainingSetMaker.js
@@ -23,9 +23,7 @@ function TrainingSetMaker() {
         />
         <Box>
           <CardContent m={2} sx={{ maxWidth: 500 }}>
-            <Typography variant="h5">
-              Training Set Maker
-            </Typography>
+            <Typography variant="h5">Training Set Maker</Typography>
             <Typography variant="body1" sx={{ mt: 1 }}>
               Creates a training set from the spatial cross-matching of a given
               Redshift Catalog and the LSST Objects Catalogs.


### PR DESCRIPTION
This commit introduces the following changes:

- Enables links to the Training Set Maker and Spec-z Catalogs pages.
- Updates the text in the TrainingSetMaker and SpeczCatalogs components to remove the "(soon)" suffix and improve clarity.
- Renames "Spec-z Catalogs" alt text to "Redshift Catalogs" in SpeczCatalogs component.