### PR TITLE
feat: always display product description in ProductDetail

### DIFF
--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -461,9 +461,7 @@ export default function ProductDetail({ productId, internalName }) {
                 )}
               </Stack>
               <Box sx={{ m: 2 }}></Box>
-              {product.release !== null && (
-                <Typography variant="body1">{product.description}</Typography>
-              )}
+              <Typography variant="body1">{product.description}</Typography>
               <ProductShare
                 isOpen={shareDialogOpen}
                 handleShareDialogOpen={handleShareDialogOpen}


### PR DESCRIPTION
This commit modifies the ProductDetail component to always display the product description, regardless of whether the product has a release associated with it. The conditional rendering based on `product.release` has been removed, ensuring that the description is consistently visible.