### PR TITLE
feat: display product type and description consistently in ProductDetail

### DIFF
--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -395,6 +395,10 @@ export default function ProductDetail({ productId, internalName }) {
                 alignItems="flex-start"
                 spacing={2}
               >
+                <Typography variant="subtitle1" color="textSecondary">
+                  <strong>Product Type:</strong> {product.product_type_name}
+                </Typography>
+
                 {product.release !== null && (
                   <Typography variant="subtitle1" color="textSecondary">
                     <strong>Release:</strong> {product.release_name}
@@ -461,7 +465,11 @@ export default function ProductDetail({ productId, internalName }) {
                 )}
               </Stack>
               <Box sx={{ m: 2 }}></Box>
-              <Typography variant="body1">{product.description}</Typography>
+              {!hasHtmlFile && (
+                <Typography variant="body" color="textSecondary">
+                  {product.description}
+                </Typography>
+              )}
               <ProductShare
                 isOpen={shareDialogOpen}
                 handleShareDialogOpen={handleShareDialogOpen}


### PR DESCRIPTION
This commit modifies the ProductDetail component to display the product type and description consistently.

- Added a "Product Type" field to display the product's type.
- Modified the product description to always display unless an HTML file exists, ensuring consistent visibility.