### PR TITLE
feat: improve specz catalogs component

### DIFF
--- a/frontend/components/ProductGrid.js
+++ b/frontend/components/ProductGrid.js
@@ -141,13 +141,6 @@ export default function ProductGrid(props) {
         sortable: false
       },
       {
-        field: 'release_year',
-        headerName: 'Release Year',
-        flex: 1,
-        maxWidth: 120,
-        sortable: true
-      },
-      {
         field: 'product_status',
         headerName: 'Status',
         flex: 1,

--- a/frontend/components/SpeczData.js
+++ b/frontend/components/SpeczData.js
@@ -1,32 +1,18 @@
 import Box from '@mui/material/Box'
-import { DataGrid } from '@mui/x-data-grid'
+import { DataGrid, GridToolbarFilterButton } from '@mui/x-data-grid'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import * as React from 'react'
-import { useQuery } from 'react-query'
-import { getProductsSpecz } from '../services/product'
 import { useEffect } from 'react'
+import { useQuery } from 'react-query'
+import { getAllProductsSpecz } from '../services/product'
 
-const DataTableWrapper = ({
-  filters,
-  query,
-  onSelectionChange,
-  clearSelection
-}) => {
-  const [page, setPage] = React.useState(0)
-  const [pageSize, setPageSize] = React.useState(10)
+const DataTableWrapper = ({ onSelectionChange, clearSelection }) => {
   const [selectedRows, setSelectedRows] = React.useState([])
 
   const { data, isLoading } = useQuery(
-    ['productData', { filters, query, page, pageSize }],
-    () =>
-      getProductsSpecz({
-        filters,
-        page,
-        page_size: pageSize,
-        sort: [{ field: 'created_at', sort: 'desc' }],
-        search: query
-      }),
+    ['productData'],
+    () => getAllProductsSpecz(),
     {
       staleTime: Infinity,
       refetchInterval: false,
@@ -78,18 +64,10 @@ const DataTableWrapper = ({
   return (
     <Box sx={{ height: 300, width: '100%' }}>
       <DataGrid
-        pageSizeOptions={[5, 10]}
         checkboxSelection
         getRowId={row => row.id || row.unique_key}
         rows={data?.results || []}
         columns={columns}
-        paginationMode="server"
-        page={page}
-        pageSize={pageSize}
-        rowCount={data?.count || 0}
-        onPageChange={newPage => setPage(newPage)}
-        onPageSizeChange={newPageSize => setPageSize(newPageSize)}
-        rowsPerPageOptions={[10]}
         loading={isLoading}
         onSelectionModelChange={newSelection =>
           handleSelectionChange(newSelection)
@@ -98,21 +76,18 @@ const DataTableWrapper = ({
           noRowsLabel: isLoading ? 'Loading...' : 'No products found'
         }}
         selectionModel={selectedRows.map(row => row.id)}
+        components={{ Toolbar: GridToolbarFilterButton }}
       />
     </Box>
   )
 }
 
 DataTableWrapper.propTypes = {
-  filters: PropTypes.object,
-  query: PropTypes.string,
   onSelectionChange: PropTypes.func,
   clearSelection: PropTypes.bool
 }
 
 DataTableWrapper.defaultProps = {
-  filters: {},
-  query: '',
   onSelectionChange: () => {},
   clearSelection: false
 }

--- a/frontend/pages/specz_catalogs.js
+++ b/frontend/pages/specz_catalogs.js
@@ -24,7 +24,6 @@ import Typography from '@mui/material/Typography'
 import { useTheme } from '@mui/system'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import SearchField from '../components/SearchField'
 import SpeczData from '../components/SpeczData'
 import { getPipelineByName } from '../services/pipeline'
 import { submitProcess } from '../services/process'
@@ -34,9 +33,9 @@ function SpeczCatalogs() {
 
   const [combinedCatalogName, setCombinedCatalogName] = useState('')
   const [resolveDuplicates, setResolveDuplicates] = useState('concatenate')
-  const [search, setSearch] = useState('')
+  // const [search, setSearch] = useState('')
   const router = useRouter()
-  const [filters] = useState({})
+  // const [filters] = useState({})
   const [snackbarOpen, setSnackbarOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
@@ -263,15 +262,15 @@ function SpeczCatalogs() {
               <Typography variant="body1" mb={1}>
                 3. Select the Redshift Catalogs to include in your sample:
               </Typography>
-              <SearchField onChange={query => setSearch(query)} />
+              {/* <SearchField onChange={query => setSearch(query)} /> */}
             </Box>
           </Grid>
           <Grid item xs={12}>
             <Card>
               <CardContent>
                 <SpeczData
-                  query={search}
-                  filters={filters}
+                  // query={search}
+                  // filters={filters}
                   onSelectionChange={handleProductSelection}
                   clearSelection={selectedProducts.length === 0}
                 />
@@ -281,7 +280,7 @@ function SpeczCatalogs() {
 
           <Grid item xs={12}>
             <Typography variant="body1">
-              4. Resolve duplicates**:
+              4. Resolve duplicates **:
               <Select
                 value={resolveDuplicates}
                 onChange={handleResolveDuplicates}
@@ -300,11 +299,15 @@ function SpeczCatalogs() {
                   galaxies.)
                 </MenuItem>
               </Select>
-              <Typography component="div" sx={{ margin: '12px' }}>
+              <Typography
+                component="div"
+                sx={{ margin: '12px' }}
+                variant="body2"
+              >
                 ** see methodology details and learn how to customize duplicates
                 resolution criteria in the{' '}
                 <Link
-                  color="inherit"
+                  underline="always"
                   href="https://docs.linea.org.br/en/sci-platforms/pz_server.html"
                 >
                   pipeline documentation

--- a/frontend/services/product.js
+++ b/frontend/services/product.js
@@ -217,6 +217,10 @@ export const createProductFile = (product_id, file, role, onUploadProgress) => {
   })
 }
 
+export const getAllProductsSpecz = async () => {
+  const res = await api.get('/api/products-specz/')
+  return res.data
+}
 
 export const getProductsSpecz = ({
   filters = {},


### PR DESCRIPTION
- Replaced server-side pagination with client-side pagination in the SpeczData component for simplicity.
- Removed the SearchField component and related search functionality from the specz_catalogs page.
- Added a GridToolbarFilterButton to the DataGrid component in SpeczData to enable filtering.
- Removed the release_year column from the ProductGrid component.
- Added a new API endpoint getAllProductsSpecz to fetch all specz products without pagination.
- Updated the documentation link in the duplicate resolution section of the specz_catalogs page.