### PR TITLE
Remove admin email from contact page

### DIFF
--- a/frontend/pages/contact.js
+++ b/frontend/pages/contact.js
@@ -61,14 +61,6 @@ export default function Contact() {
                   )}
                 </p>
                 <p>
-                  Photo-z Server development team:{' '}
-                  {emails.lead ? (
-                    <Link href={`mailto:${emails.admin}`}>{emails.admin}</Link>
-                  ) : (
-                    'Loading...'
-                  )}
-                </p>
-                <p>
                   Technical support:{' '}
                   {emails.support ? (
                     <Link href={`mailto:${emails.support}`}>


### PR DESCRIPTION
@crisingulani  este email de administrador não existe, seria criado mas a infra preferiu centralizar o recebimento de pedidos de ajuda e feedback no helpdesk. Fiz a alteração direto na página do github. Pode verificar por favor e levar para produção o mais rápido possível?