### PR TITLE
fix(ProductDataGrid): increase column width with minWidth property

### DIFF
--- a/frontend/components/ProductDataGrid.js
+++ b/frontend/components/ProductDataGrid.js
@@ -48,7 +48,8 @@ export default function ProductDataGrid(props) {
         field: name,
         headerName: name,
         sortable: false,
-        flex: 1
+        flex: 1,
+        minWidth: 100
       }
     })
     setColumns(cols)


### PR DESCRIPTION
##### Implementado:

Largura mínima de 100px (~10 caracteres) por coluna no table preview (`minWidth: 100`). O scroll lateral continua funcionando normalmente para visualizar as demais colunas.


#### Pendente:

O redimensionamento de colunas via `drag` (arrastar a borda da coluna) não foi implementado pois essa funcionalidade só está disponível na versão free do `@mui/x-data-grid` a partir da `v7`, que requer `@mui/system@^5.15.14` com o módulo `RtlProvider`, incompatível com a versão atual do projeto. Para habilitar o resize, é recomendado atualizar o React (de 17 para 18) e o MUI (`@mui/material`, `@mui/system` e `@mui/x-data-grid`) para as versões mais recentes.

@gschwend Vale a pena criar uma issue para planejar essas atualizações, pois isso facilitará ajustes e a implementação de novas funcionalidades no futuro.