### PR TITLE
feat(navigation): add new navigation links for Data Products, Upload, and Pipelines

### DIFF
--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -51,6 +51,18 @@ function Header(props) {
       href: '/'
     },
     {
+      description: 'Data Products',
+      href: '/user_products'
+    },
+    {
+      description: 'Upload',
+      href: '/product/new'
+    },
+    {
+      description: 'Pipelines',
+      href: '/pz_pipelines'
+    },
+    {
       description: 'About',
       href: '/about'
     },

--- a/frontend/pages/user_products.js
+++ b/frontend/pages/user_products.js
@@ -166,7 +166,17 @@ export default function Products() {
               router.push('/product/new')
             }}
           >
-            New Product
+            Upload
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            sx={{ ml: 1 }}
+            onClick={() => {
+              router.push('/pz_pipelines')
+            }}
+          >
+            Create
           </Button>
         </Grid>
       </Grid>


### PR DESCRIPTION
#### Summary
  Added three new navigation links to the header menu between Home and About: Data Products (`/user_products`), **Upload** (`/product/new`), and Pipelines (`/pz_pipelines`). Works on both desktop and mobile drawer.

On the User-generated Data Products page, renamed the "New Product" button to "**Upload**" and added a new "**Create**" button linking to `/pz_pipelines`.

All links use relative paths, ensuring compatibility across local, dev, and production environments.

<img width="1904" height="306" alt="image" src="https://github.com/user-attachments/assets/a0a6cac2-31d3-4ea5-8e5d-8e6d00603317" />
