### PR TITLE
fix: adjust input box size for better usability

### DIFF
--- a/frontend/components/SpeczData.js
+++ b/frontend/components/SpeczData.js
@@ -62,7 +62,15 @@ const DataTableWrapper = ({ onSelectionChange, clearSelection }) => {
   ]
 
   return (
-    <Box sx={{ height: 300, width: '100%' }}>
+    <Box
+      sx={{
+        height: 300,
+        minHeight: 200,
+        width: '100%',
+        resize: 'vertical',
+        overflow: 'auto'
+      }}
+    >
       <DataGrid
         checkboxSelection
         getRowId={row => row.id || row.unique_key}


### PR DESCRIPTION
The input selection box in the "Combine Redshift Catalogs" pipeline can now be resized vertically. Simply drag the handle in the bottom right corner of the box to increase or decrease the visible area, allowing you to view more list items without having to scroll.

<img width="1866" height="465" alt="image" src="https://github.com/user-attachments/assets/706a86b7-7c8a-42a4-8e58-b17538c419f8" />
