### PR TITLE
fix: enhance form reset functionality in TrainingSetMaker and update DataTableWrapper to handle selectedProductId

### DIFF
--- a/frontend/components/TsmData.js
+++ b/frontend/components/TsmData.js
@@ -7,10 +7,19 @@ import * as React from 'react'
 import { useQuery } from 'react-query'
 import { getProductsSpecz } from '../services/product'
 
-const DataTableWrapper = ({ filters, query, onProductSelect }) => {
+const DataTableWrapper = ({
+  filters,
+  query,
+  onProductSelect,
+  selectedProductId
+}) => {
   const [page, setPage] = React.useState(0)
   const [pageSize, setPageSize] = React.useState(10)
   const [selectedRowId, setSelectedRowId] = React.useState(null)
+
+  React.useEffect(() => {
+    setSelectedRowId(selectedProductId)
+  }, [selectedProductId])
 
   const { data, isLoading } = useQuery(
     ['productData', { filters, query, page, pageSize }],
@@ -102,7 +111,8 @@ const DataTableWrapper = ({ filters, query, onProductSelect }) => {
 DataTableWrapper.propTypes = {
   filters: PropTypes.object,
   query: PropTypes.string,
-  onProductSelect: PropTypes.func
+  onProductSelect: PropTypes.func,
+  selectedProductId: PropTypes.number
 }
 
 DataTableWrapper.defaultProps = {

--- a/frontend/pages/specz_catalogs.js
+++ b/frontend/pages/specz_catalogs.js
@@ -71,6 +71,14 @@ function SpeczCatalogs() {
     setFlagToCut('3.0')
     setSelectedProducts([])
     setOutputFormat('parquet')
+    setResolveDuplicates('concatenate')
+    setData(prevData => ({
+      ...initialData.system_config,
+      param: {
+        ...initialData.system_config.param,
+        description: ''
+      }
+    }))
   }
 
   const handleResolveDuplicates = event => {

--- a/frontend/pages/training_set_maker.js
+++ b/frontend/pages/training_set_maker.js
@@ -173,21 +173,21 @@ function TrainingSetMaker() {
       ...initialData.system_config,
       param: {
         ...initialData.system_config.param,
-        description: '',
-        flux_type: '',
-        dereddening: ''
+        description: ''
       }
     }))
-    setSelectedLsstCatalog('')
+    if (releases.length > 0) {
+      handleRelease(releases[0].name)
+    } else {
+      setSelectedLsstCatalog('')
+      setFluxes([])
+      setDereddening([])
+    }
     setOutputFormat('specz')
     setIsSubmitting(false)
     setSelectedProductId(null)
-    setConvertFluxToMag(true)
-    setDisabledConvertFluxToMag(false)
     setUniqueGalaxies(false)
     setSearch('')
-    setFluxes([])
-    setDereddening([])
   }
 
   const handleRelease = (releaseName, releasesData) => {

--- a/frontend/pages/training_set_maker.js
+++ b/frontend/pages/training_set_maker.js
@@ -169,10 +169,25 @@ function TrainingSetMaker() {
 
   const handleClearForm = () => {
     setCombinedCatalogName('')
-    setData(initialData.system_config)
+    setData(prevData => ({
+      ...initialData.system_config,
+      param: {
+        ...initialData.system_config.param,
+        description: '',
+        flux_type: '',
+        dereddening: ''
+      }
+    }))
     setSelectedLsstCatalog('')
     setOutputFormat('specz')
     setIsSubmitting(false)
+    setSelectedProductId(null)
+    setConvertFluxToMag(true)
+    setDisabledConvertFluxToMag(false)
+    setUniqueGalaxies(false)
+    setSearch('')
+    setFluxes([])
+    setDereddening([])
   }
 
   const handleRelease = (releaseName, releasesData) => {
@@ -428,6 +443,7 @@ function TrainingSetMaker() {
                 <TsmData
                   query={search}
                   onProductSelect={setSelectedProductId}
+                  selectedProductId={selectedProductId}
                 />
               </CardContent>
             </Card>


### PR DESCRIPTION

Corrigido o botão "Clear Form" nos pipelines Combine Redshift Catalogs e Training Set Maker. Agora todos os campos são resetados corretamente, incluindo description, seleção de inputs, dropdowns de configuração e checkboxes que antes mantinham valores antigos após limpar o formulário.