### PR TITLE
Padroniza filtros e paginação da seleção de inputs no CRC e TSM (#559)

### DIFF
--- a/frontend/components/SpeczData.js
+++ b/frontend/components/SpeczData.js
@@ -35,10 +35,14 @@ const DataTableWrapper = ({
     }
   )
 
-  // Reset paginação quando a busca/filtros mudam
+  // Reset paginação quando a busca/filtros mudam.
+  // Serializa os filtros: como `filters` é um objeto recriado a cada render,
+  // usar ele direto como dependência dispararia o efeito em todo render,
+  // travando a paginação sempre na primeira página.
+  const filtersKey = JSON.stringify(filters)
   useEffect(() => {
     setPage(0)
-  }, [query, filters])
+  }, [query, filtersKey])
 
   const handleSelectionChange = selection => {
     const currentPageProducts = data?.results || []

--- a/frontend/components/SpeczData.js
+++ b/frontend/components/SpeczData.js
@@ -5,30 +5,53 @@ import PropTypes from 'prop-types'
 import * as React from 'react'
 import { useEffect } from 'react'
 import { useQuery } from 'react-query'
-import { getAllProductsSpecz } from '../services/product'
+import { getProductsSpecz } from '../services/product'
 
 const DataTableWrapper = ({
+  filters = {},
+  query = '',
   onSelectionChange = () => {},
   clearSelection = false
 }) => {
+  const [page, setPage] = React.useState(0)
+  const [pageSize, setPageSize] = React.useState(25)
   const [selectedRows, setSelectedRows] = React.useState([])
 
   const { data, isLoading } = useQuery(
-    ['productData'],
-    () => getAllProductsSpecz(),
+    ['productData', { filters, query, page, pageSize }],
+    () =>
+      getProductsSpecz({
+        filters,
+        page,
+        page_size: pageSize,
+        sort: [{ field: 'created_at', sort: 'desc' }],
+        search: query
+      }),
     {
+      keepPreviousData: true,
       staleTime: Infinity,
       refetchInterval: false,
       retry: false
     }
   )
 
+  // Reset paginação quando a busca/filtros mudam
+  useEffect(() => {
+    setPage(0)
+  }, [query, filters])
+
   const handleSelectionChange = selection => {
-    const selectedProducts = selection.map(
-      id => data?.results?.find(product => product.id === id) || {}
+    const currentPageProducts = data?.results || []
+    const previousSelection = selectedRows.filter(
+      row => !currentPageProducts.some(p => p.id === row.id)
     )
-    setSelectedRows(selectedProducts)
-    onSelectionChange(selectedProducts)
+    const newSelectionFromPage = selection
+      .map(id => currentPageProducts.find(product => product.id === id))
+      .filter(Boolean)
+
+    const merged = [...previousSelection, ...newSelectionFromPage]
+    setSelectedRows(merged)
+    onSelectionChange(merged)
   }
 
   useEffect(() => {
@@ -67,7 +90,7 @@ const DataTableWrapper = ({
   return (
     <Box
       sx={{
-        height: 300,
+        height: 400,
         minHeight: 200,
         width: '100%',
         resize: 'vertical',
@@ -76,10 +99,18 @@ const DataTableWrapper = ({
     >
       <DataGrid
         checkboxSelection
+        keepNonExistentRowsSelected
         getRowId={row => row.id || row.unique_key}
         rows={data?.results || []}
         columns={columns}
         loading={isLoading}
+        paginationMode="server"
+        page={page}
+        pageSize={pageSize}
+        rowCount={data?.count || 0}
+        onPageChange={newPage => setPage(newPage)}
+        onPageSizeChange={newPageSize => setPageSize(newPageSize)}
+        rowsPerPageOptions={[10, 25, 50]}
         onSelectionModelChange={newSelection =>
           handleSelectionChange(newSelection)
         }
@@ -94,6 +125,8 @@ const DataTableWrapper = ({
 }
 
 DataTableWrapper.propTypes = {
+  filters: PropTypes.object,
+  query: PropTypes.string,
   onSelectionChange: PropTypes.func,
   clearSelection: PropTypes.bool
 }

--- a/frontend/components/TsmData.js
+++ b/frontend/components/TsmData.js
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box'
 import Radio from '@mui/material/Radio'
-import { DataGrid } from '@mui/x-data-grid'
+import { DataGrid, GridToolbarFilterButton } from '@mui/x-data-grid'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import * as React from 'react'
@@ -14,12 +14,16 @@ const DataTableWrapper = ({
   selectedProductId
 }) => {
   const [page, setPage] = React.useState(0)
-  const [pageSize, setPageSize] = React.useState(10)
+  const [pageSize, setPageSize] = React.useState(25)
   const [selectedRowId, setSelectedRowId] = React.useState(null)
 
   React.useEffect(() => {
     setSelectedRowId(selectedProductId)
   }, [selectedProductId])
+
+  React.useEffect(() => {
+    setPage(0)
+  }, [query, filters])
 
   const { data, isLoading } = useQuery(
     ['productData', { filters, query, page, pageSize }],
@@ -32,6 +36,7 @@ const DataTableWrapper = ({
         search: query
       }),
     {
+      keepPreviousData: true,
       staleTime: Infinity,
       refetchInterval: false,
       retry: false
@@ -96,12 +101,13 @@ const DataTableWrapper = ({
           rowCount={data?.count || 0}
           onPageChange={newPage => setPage(newPage)}
           onPageSizeChange={newPageSize => setPageSize(newPageSize)}
-          rowsPerPageOptions={[10]}
+          rowsPerPageOptions={[10, 25, 50]}
           loading={isLoading}
           localeText={{
             noRowsLabel: isLoading ? 'Loading...' : 'No products found'
           }}
           onRowClick={params => handleRowSelection(params.row.id)}
+          components={{ Toolbar: GridToolbarFilterButton }}
         />
       </Box>
     </>

--- a/frontend/components/TsmData.js
+++ b/frontend/components/TsmData.js
@@ -21,9 +21,14 @@ const DataTableWrapper = ({
     setSelectedRowId(selectedProductId)
   }, [selectedProductId])
 
+  // Reset paginação quando a busca/filtros mudam.
+  // Serializa os filtros: como `filters` é um objeto recriado a cada render,
+  // usar ele direto como dependência dispararia o efeito em todo render,
+  // travando a paginação sempre na primeira página.
+  const filtersKey = JSON.stringify(filters)
   React.useEffect(() => {
     setPage(0)
-  }, [query, filters])
+  }, [query, filtersKey])
 
   const { data, isLoading } = useQuery(
     ['productData', { filters, query, page, pageSize }],

--- a/frontend/pages/specz_catalogs.js
+++ b/frontend/pages/specz_catalogs.js
@@ -22,6 +22,7 @@ import Typography from '@mui/material/Typography'
 import { useTheme } from '@mui/system'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import SearchField from '../components/SearchField'
 import SpeczData from '../components/SpeczData'
 import { getPipelineByName } from '../services/pipeline'
 import { submitProcess } from '../services/process'
@@ -48,6 +49,7 @@ function SpeczCatalogs() {
   const [fieldErrors] = useState({})
   const [selectedProducts, setSelectedProducts] = useState([])
   const [outputFormat, setOutputFormat] = useState('parquet')
+  const [search, setSearch] = useState('')
 
   useEffect(() => {
     const fetchPipelineData = async () => {
@@ -264,13 +266,12 @@ function SpeczCatalogs() {
               <Typography variant="body1" mb={1}>
                 3. Select the Redshift Catalogs to include in your sample:
               </Typography>
-              {/* <SearchField onChange={query => setSearch(query)} /> */}
+              <SearchField onChange={query => setSearch(query)} />
             </Box>
             <Card>
               <CardContent>
                 <SpeczData
-                  // query={search}
-                  // filters={filters}
+                  query={search}
                   onSelectionChange={handleProductSelection}
                   clearSelection={selectedProducts.length === 0}
                 />

--- a/frontend/services/product.js
+++ b/frontend/services/product.js
@@ -258,11 +258,6 @@ export const getProductConfigFiles = async productId => {
   }
 }
 
-export const getAllProductsSpecz = async () => {
-  const res = await api.get('/api/products-specz/')
-  return res.data
-}
-
 export const getProductsSpecz = ({
   filters = {},
   search = '',


### PR DESCRIPTION
Padroniza a etapa de seleção de catálogos de redshift nos dois pipelines
(CRC e TSM) e corrige a paginação que estava 100% no front no CRC.

### CRC (`/specz_catalogs`)
- Habilita a busca por nome (campo Search) que já existia comentada
- Paginação passa a ser server-side, usando o `getProductsSpecz` que o TSM
  já usa (params `page`, `page_size`, `search`, `ordering`). Antes o
  componente chamava `getAllProductsSpecz` e baixava a lista inteira de
  uma vez, o que travava conforme a base cresce
- Seleção múltipla agora persiste entre páginas (`keepNonExistentRowsSelected`)
- `pageSize` default 25, opções 10/25/50

### TSM (`/training_set_maker`)
- Adicionado o botão FILTERS por coluna, mesmo do CRC
- `pageSize` default sobe de 10 pra 25, opções 10/25/50

### Service
- Removida `getAllProductsSpecz` (sem uso depois da migração)

## Backend
Nenhuma mudança. O endpoint `/api/products-specz/` já aceitava `page`,
`page_size`, `search` e `ordering` — só faltava o CRC usar.

## Como testar

1. `docker compose up -d`
2. Abrir `http://localhost/specz_catalogs`:
   - DevTools → Network: a primeira chamada deve ser
     `/api/products-specz/?page=1&page_size=25&ordering=-created_at`
     (não baixa tudo de uma vez)
   - Trocar de página dispara `page=2`
   - Digitar no Search dispara `search=...` depois de ~600ms (debounce)
   - Botão FILTERS abre filtros por coluna
   - Selecionar um item na página 1, ir pra página 2 e voltar: a seleção
     continua marcada
3. Abrir `http://localhost/training_set_maker`:
   - Botão FILTERS agora aparece
   - Listagem continua com radio (seleção única) e busca funcionando

## Notas

- O `GridToolbarFilterButton` filtra apenas as linhas já carregadas na
  página atual (limitação nativa do MUI DataGrid com paginação server-side).
  Pra busca em toda a base, usar o campo Search.
- Mantidas as diferenças semânticas de seleção: CRC continua com checkbox
  (múltipla) e TSM com radio (única).