### PR TITLE
Adiciona filtro "Official products" na seleção de inputs dos pipelines (#472)

### DIFF
--- a/frontend/components/SpeczData.js
+++ b/frontend/components/SpeczData.js
@@ -1,4 +1,9 @@
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Stack from '@mui/material/Stack'
 import { DataGrid, GridToolbarFilterButton } from '@mui/x-data-grid'
 import moment from 'moment'
 import PropTypes from 'prop-types'
@@ -54,11 +59,22 @@ const DataTableWrapper = ({
     onSelectionChange(merged)
   }
 
+  const handleClearAll = () => {
+    setSelectedRows([])
+    onSelectionChange([])
+  }
+
   useEffect(() => {
     if (clearSelection) {
       setSelectedRows([])
     }
   }, [clearSelection])
+
+  const visibleIds = new Set((data?.results || []).map(r => r.id))
+  const visibleSelectedCount = selectedRows.filter(r =>
+    visibleIds.has(r.id)
+  ).length
+  const hiddenSelectedCount = selectedRows.length - visibleSelectedCount
 
   const columns = [
     {
@@ -88,39 +104,66 @@ const DataTableWrapper = ({
   ]
 
   return (
-    <Box
-      sx={{
-        height: 400,
-        minHeight: 200,
-        width: '100%',
-        resize: 'vertical',
-        overflow: 'auto'
-      }}
-    >
-      <DataGrid
-        checkboxSelection
-        keepNonExistentRowsSelected
-        getRowId={row => row.id || row.unique_key}
-        rows={data?.results || []}
-        columns={columns}
-        loading={isLoading}
-        paginationMode="server"
-        page={page}
-        pageSize={pageSize}
-        rowCount={data?.count || 0}
-        onPageChange={newPage => setPage(newPage)}
-        onPageSizeChange={newPageSize => setPageSize(newPageSize)}
-        rowsPerPageOptions={[10, 25, 50]}
-        onSelectionModelChange={newSelection =>
-          handleSelectionChange(newSelection)
-        }
-        localeText={{
-          noRowsLabel: isLoading ? 'Loading...' : 'No products found'
+    <Stack spacing={1}>
+      {selectedRows.length > 0 && (
+        <Alert
+          severity={hiddenSelectedCount > 0 ? 'warning' : 'info'}
+          icon={<InfoOutlinedIcon fontSize="inherit" />}
+          action={
+            <Button color="inherit" size="small" onClick={handleClearAll}>
+              Clear all
+            </Button>
+          }
+          sx={{ py: 0 }}
+        >
+          <Chip
+            label={`${selectedRows.length} selected`}
+            size="small"
+            color="primary"
+            sx={{ mr: 1 }}
+          />
+          {hiddenSelectedCount > 0 && (
+            <span>
+              {hiddenSelectedCount} item{hiddenSelectedCount > 1 ? 's' : ''}{' '}
+              currently hidden by search/filter. They will still be submitted.
+            </span>
+          )}
+        </Alert>
+      )}
+      <Box
+        sx={{
+          height: 400,
+          minHeight: 200,
+          width: '100%',
+          resize: 'vertical',
+          overflow: 'auto'
         }}
-        selectionModel={selectedRows.map(row => row.id)}
-        components={{ Toolbar: GridToolbarFilterButton }}
-      />
-    </Box>
+      >
+        <DataGrid
+          checkboxSelection
+          keepNonExistentRowsSelected
+          getRowId={row => row.id || row.unique_key}
+          rows={data?.results || []}
+          columns={columns}
+          loading={isLoading}
+          paginationMode="server"
+          page={page}
+          pageSize={pageSize}
+          rowCount={data?.count || 0}
+          onPageChange={newPage => setPage(newPage)}
+          onPageSizeChange={newPageSize => setPageSize(newPageSize)}
+          rowsPerPageOptions={[10, 25, 50]}
+          onSelectionModelChange={newSelection =>
+            handleSelectionChange(newSelection)
+          }
+          localeText={{
+            noRowsLabel: isLoading ? 'Loading...' : 'No products found'
+          }}
+          selectionModel={selectedRows.map(row => row.id)}
+          components={{ Toolbar: GridToolbarFilterButton }}
+        />
+      </Box>
+    </Stack>
   )
 }
 

--- a/frontend/components/SpeczData.js
+++ b/frontend/components/SpeczData.js
@@ -40,10 +40,14 @@ const DataTableWrapper = ({
     }
   )
 
-  // Reset paginação quando a busca/filtros mudam
+  // Reset paginação quando a busca/filtros mudam.
+  // Serializa os filtros: como `filters` é um objeto recriado a cada render,
+  // usar ele direto como dependência dispararia o efeito em todo render,
+  // travando a paginação sempre na primeira página.
+  const filtersKey = JSON.stringify(filters)
   useEffect(() => {
     setPage(0)
-  }, [query, filters])
+  }, [query, filtersKey])
 
   const handleSelectionChange = selection => {
     const currentPageProducts = data?.results || []

--- a/frontend/components/SpeczData.js
+++ b/frontend/components/SpeczData.js
@@ -5,30 +5,53 @@ import PropTypes from 'prop-types'
 import * as React from 'react'
 import { useEffect } from 'react'
 import { useQuery } from 'react-query'
-import { getAllProductsSpecz } from '../services/product'
+import { getProductsSpecz } from '../services/product'
 
 const DataTableWrapper = ({
+  filters = {},
+  query = '',
   onSelectionChange = () => {},
   clearSelection = false
 }) => {
+  const [page, setPage] = React.useState(0)
+  const [pageSize, setPageSize] = React.useState(25)
   const [selectedRows, setSelectedRows] = React.useState([])
 
   const { data, isLoading } = useQuery(
-    ['productData'],
-    () => getAllProductsSpecz(),
+    ['productData', { filters, query, page, pageSize }],
+    () =>
+      getProductsSpecz({
+        filters,
+        page,
+        page_size: pageSize,
+        sort: [{ field: 'created_at', sort: 'desc' }],
+        search: query
+      }),
     {
+      keepPreviousData: true,
       staleTime: Infinity,
       refetchInterval: false,
       retry: false
     }
   )
 
+  // Reset paginação quando a busca/filtros mudam
+  useEffect(() => {
+    setPage(0)
+  }, [query, filters])
+
   const handleSelectionChange = selection => {
-    const selectedProducts = selection.map(
-      id => data?.results?.find(product => product.id === id) || {}
+    const currentPageProducts = data?.results || []
+    const previousSelection = selectedRows.filter(
+      row => !currentPageProducts.some(p => p.id === row.id)
     )
-    setSelectedRows(selectedProducts)
-    onSelectionChange(selectedProducts)
+    const newSelectionFromPage = selection
+      .map(id => currentPageProducts.find(product => product.id === id))
+      .filter(Boolean)
+
+    const merged = [...previousSelection, ...newSelectionFromPage]
+    setSelectedRows(merged)
+    onSelectionChange(merged)
   }
 
   useEffect(() => {
@@ -67,7 +90,7 @@ const DataTableWrapper = ({
   return (
     <Box
       sx={{
-        height: 300,
+        height: 400,
         minHeight: 200,
         width: '100%',
         resize: 'vertical',
@@ -76,10 +99,18 @@ const DataTableWrapper = ({
     >
       <DataGrid
         checkboxSelection
+        keepNonExistentRowsSelected
         getRowId={row => row.id || row.unique_key}
         rows={data?.results || []}
         columns={columns}
         loading={isLoading}
+        paginationMode="server"
+        page={page}
+        pageSize={pageSize}
+        rowCount={data?.count || 0}
+        onPageChange={newPage => setPage(newPage)}
+        onPageSizeChange={newPageSize => setPageSize(newPageSize)}
+        rowsPerPageOptions={[10, 25, 50]}
         onSelectionModelChange={newSelection =>
           handleSelectionChange(newSelection)
         }
@@ -94,6 +125,8 @@ const DataTableWrapper = ({
 }
 
 DataTableWrapper.propTypes = {
+  filters: PropTypes.object,
+  query: PropTypes.string,
   onSelectionChange: PropTypes.func,
   clearSelection: PropTypes.bool
 }

--- a/frontend/components/TsmData.js
+++ b/frontend/components/TsmData.js
@@ -26,9 +26,14 @@ const DataTableWrapper = ({
     setSelectedRowId(selectedProductId)
   }, [selectedProductId])
 
+  // Reset paginação quando a busca/filtros mudam.
+  // Serializa os filtros: como `filters` é um objeto recriado a cada render,
+  // usar ele direto como dependência dispararia o efeito em todo render,
+  // travando a paginação sempre na primeira página.
+  const filtersKey = JSON.stringify(filters)
   React.useEffect(() => {
     setPage(0)
-  }, [query, filters])
+  }, [query, filtersKey])
 
   const { data, isLoading } = useQuery(
     ['productData', { filters, query, page, pageSize }],

--- a/frontend/components/TsmData.js
+++ b/frontend/components/TsmData.js
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box'
 import Radio from '@mui/material/Radio'
-import { DataGrid } from '@mui/x-data-grid'
+import { DataGrid, GridToolbarFilterButton } from '@mui/x-data-grid'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import * as React from 'react'
@@ -14,12 +14,16 @@ const DataTableWrapper = ({
   selectedProductId
 }) => {
   const [page, setPage] = React.useState(0)
-  const [pageSize, setPageSize] = React.useState(10)
+  const [pageSize, setPageSize] = React.useState(25)
   const [selectedRowId, setSelectedRowId] = React.useState(null)
 
   React.useEffect(() => {
     setSelectedRowId(selectedProductId)
   }, [selectedProductId])
+
+  React.useEffect(() => {
+    setPage(0)
+  }, [query, filters])
 
   const { data, isLoading } = useQuery(
     ['productData', { filters, query, page, pageSize }],
@@ -32,6 +36,7 @@ const DataTableWrapper = ({
         search: query
       }),
     {
+      keepPreviousData: true,
       staleTime: Infinity,
       refetchInterval: false,
       retry: false
@@ -96,12 +101,13 @@ const DataTableWrapper = ({
           rowCount={data?.count || 0}
           onPageChange={newPage => setPage(newPage)}
           onPageSizeChange={newPageSize => setPageSize(newPageSize)}
-          rowsPerPageOptions={[10]}
+          rowsPerPageOptions={[10, 25, 50]}
           loading={isLoading}
           localeText={{
             noRowsLabel: isLoading ? 'Loading...' : 'No products found'
           }}
           onRowClick={params => handleRowSelection(params.row.id)}
+          components={{ Toolbar: GridToolbarFilterButton }}
         />
       </Box>
     </>

--- a/frontend/components/TsmData.js
+++ b/frontend/components/TsmData.js
@@ -1,5 +1,9 @@
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Radio from '@mui/material/Radio'
+import Stack from '@mui/material/Stack'
 import { DataGrid, GridToolbarFilterButton } from '@mui/x-data-grid'
 import moment from 'moment'
 import PropTypes from 'prop-types'
@@ -16,6 +20,7 @@ const DataTableWrapper = ({
   const [page, setPage] = React.useState(0)
   const [pageSize, setPageSize] = React.useState(25)
   const [selectedRowId, setSelectedRowId] = React.useState(null)
+  const [selectedRowName, setSelectedRowName] = React.useState(null)
 
   React.useEffect(() => {
     setSelectedRowId(selectedProductId)
@@ -43,12 +48,26 @@ const DataTableWrapper = ({
     }
   )
 
-  const handleRowSelection = rowId => {
+  const handleRowSelection = (rowId, rowName) => {
     setSelectedRowId(rowId)
+    setSelectedRowName(rowName)
     if (onProductSelect) {
       onProductSelect(rowId)
     }
   }
+
+  const handleClear = () => {
+    setSelectedRowId(null)
+    setSelectedRowName(null)
+    if (onProductSelect) {
+      onProductSelect(null)
+    }
+  }
+
+  const isSelectionVisible =
+    selectedRowId != null &&
+    (data?.results || []).some(r => r.id === selectedRowId)
+  const hasHiddenSelection = selectedRowId != null && !isSelectionVisible
 
   const columns = [
     {
@@ -57,7 +76,9 @@ const DataTableWrapper = ({
       renderCell: params => (
         <Radio
           checked={selectedRowId === params.row.id}
-          onChange={() => handleRowSelection(params.row.id)}
+          onChange={() =>
+            handleRowSelection(params.row.id, params.row.display_name)
+          }
         />
       ),
       width: 50
@@ -89,7 +110,23 @@ const DataTableWrapper = ({
   ]
 
   return (
-    <>
+    <Stack spacing={1}>
+      {hasHiddenSelection && (
+        <Alert
+          severity="warning"
+          icon={<InfoOutlinedIcon fontSize="inherit" />}
+          action={
+            <Button color="inherit" size="small" onClick={handleClear}>
+              Clear
+            </Button>
+          }
+          sx={{ py: 0 }}
+        >
+          The selected catalog
+          {selectedRowName ? ` (${selectedRowName})` : ''} is hidden by the
+          current search/filter. It will still be submitted.
+        </Alert>
+      )}
       <Box sx={{ height: 400, width: '100%' }}>
         <DataGrid
           getRowId={row => row.id || row.unique_key}
@@ -106,11 +143,13 @@ const DataTableWrapper = ({
           localeText={{
             noRowsLabel: isLoading ? 'Loading...' : 'No products found'
           }}
-          onRowClick={params => handleRowSelection(params.row.id)}
+          onRowClick={params =>
+            handleRowSelection(params.row.id, params.row.display_name)
+          }
           components={{ Toolbar: GridToolbarFilterButton }}
         />
       </Box>
-    </>
+    </Stack>
   )
 }
 

--- a/frontend/pages/specz_catalogs.js
+++ b/frontend/pages/specz_catalogs.js
@@ -22,6 +22,7 @@ import Typography from '@mui/material/Typography'
 import { useTheme } from '@mui/system'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import SearchField from '../components/SearchField'
 import SpeczData from '../components/SpeczData'
 import { getPipelineByName } from '../services/pipeline'
 import { submitProcess } from '../services/process'
@@ -48,6 +49,7 @@ function SpeczCatalogs() {
   const [fieldErrors] = useState({})
   const [selectedProducts, setSelectedProducts] = useState([])
   const [outputFormat, setOutputFormat] = useState('parquet')
+  const [search, setSearch] = useState('')
 
   useEffect(() => {
     const fetchPipelineData = async () => {
@@ -264,13 +266,12 @@ function SpeczCatalogs() {
               <Typography variant="body1" mb={1}>
                 3. Select the Redshift Catalogs to include in your sample:
               </Typography>
-              {/* <SearchField onChange={query => setSearch(query)} /> */}
+              <SearchField onChange={query => setSearch(query)} />
             </Box>
             <Card>
               <CardContent>
                 <SpeczData
-                  // query={search}
-                  // filters={filters}
+                  query={search}
                   onSelectionChange={handleProductSelection}
                   clearSelection={selectedProducts.length === 0}
                 />

--- a/frontend/pages/specz_catalogs.js
+++ b/frontend/pages/specz_catalogs.js
@@ -4,12 +4,14 @@ import Breadcrumbs from '@mui/material/Breadcrumbs'
 import Button from '@mui/material/Button'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
+import Checkbox from '@mui/material/Checkbox'
 import CircularProgress from '@mui/material/CircularProgress'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import FormControl from '@mui/material/FormControl'
+import FormControlLabel from '@mui/material/FormControlLabel'
 import Grid from '@mui/material/Grid'
 import Link from '@mui/material/Link'
 import MenuItem from '@mui/material/MenuItem'
@@ -50,6 +52,7 @@ function SpeczCatalogs() {
   const [selectedProducts, setSelectedProducts] = useState([])
   const [outputFormat, setOutputFormat] = useState('parquet')
   const [search, setSearch] = useState('')
+  const [officialOnly, setOfficialOnly] = useState(false)
 
   useEffect(() => {
     const fetchPipelineData = async () => {
@@ -267,11 +270,22 @@ function SpeczCatalogs() {
                 3. Select the Redshift Catalogs to include in your sample:
               </Typography>
               <SearchField onChange={query => setSearch(query)} />
+              <FormControlLabel
+                sx={{ ml: 1 }}
+                control={
+                  <Checkbox
+                    checked={officialOnly}
+                    onChange={e => setOfficialOnly(e.target.checked)}
+                  />
+                }
+                label="Official products"
+              />
             </Box>
             <Card>
               <CardContent>
                 <SpeczData
                   query={search}
+                  filters={officialOnly ? { official_product: true } : {}}
                   onSelectionChange={handleProductSelection}
                   clearSelection={selectedProducts.length === 0}
                 />

--- a/frontend/pages/training_set_maker.js
+++ b/frontend/pages/training_set_maker.js
@@ -11,6 +11,7 @@ import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import FormControl from '@mui/material/FormControl'
+import FormControlLabel from '@mui/material/FormControlLabel'
 import Grid from '@mui/material/Grid'
 import Link from '@mui/material/Link'
 import MenuItem from '@mui/material/MenuItem'
@@ -45,6 +46,7 @@ function TrainingSetMaker() {
   const [disabledFluxToMag, setDisabledConvertFluxToMag] = useState(false)
   const [combinedCatalogName, setCombinedCatalogName] = useState('')
   const [search, setSearch] = useState('')
+  const [officialOnly, setOfficialOnly] = useState(false)
   const [selectedProductId, setSelectedProductId] = useState(null)
   const [snackbarOpen, setSnackbarOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -192,6 +194,7 @@ function TrainingSetMaker() {
     setSelectedProductId(null)
     setUniqueGalaxies(false)
     setSearch('')
+    setOfficialOnly(false)
   }
 
   const handleRelease = (releaseName, releasesData) => {
@@ -438,6 +441,16 @@ function TrainingSetMaker() {
                 3. Select the Redshift Catalog for the cross-matching:
               </Typography>
               <SearchField onChange={query => setSearch(query)} />
+              <FormControlLabel
+                sx={{ ml: 1 }}
+                control={
+                  <Checkbox
+                    checked={officialOnly}
+                    onChange={e => setOfficialOnly(e.target.checked)}
+                  />
+                }
+                label="Official products"
+              />
             </Box>
           </Grid>
 
@@ -446,6 +459,7 @@ function TrainingSetMaker() {
               <CardContent>
                 <TsmData
                   query={search}
+                  filters={officialOnly ? { official_product: true } : {}}
                   onProductSelect={setSelectedProductId}
                   selectedProductId={selectedProductId}
                 />

--- a/frontend/services/product.js
+++ b/frontend/services/product.js
@@ -258,11 +258,6 @@ export const getProductConfigFiles = async productId => {
   }
 }
 
-export const getAllProductsSpecz = async () => {
-  const res = await api.get('/api/products-specz/')
-  return res.data
-}
-
 export const getProductsSpecz = ({
   filters = {},
   search = '',


### PR DESCRIPTION
> Depende do #559 — este branch foi mergeado em cima dele.

## O que muda

Adiciona um checkbox "Official products" ao lado do Search nas etapas de
seleção de catálogos do CRC (`/specz_catalogs`) e do TSM
(`/training_set_maker`). Quando marcado, a listagem filtra para mostrar
apenas produtos oficiais. Desmarcado, mostra todos (default).

Também coloquei um alerta visual em cima do data grid para deixar claro
quando há seleções fora da view atual (escondidas por filtro ou em outra
página da paginação), com botão "Clear all" / "Clear" para resetar
rapidamente. Isso evita o caso de submeter o pipeline com itens que o
usuário esqueceu que estavam selecionados.

## Backend

Nenhuma mudança. O endpoint `/api/products-specz/` já aceita o filtro
`official_product` via `ProductFilter` (mesmo filtro usado em
`/oficial_products`).

## Como testar

1. Em `/specz_catalogs`:
   - Marcar "Official products" → lista filtra (Network: `?official_product=true`)
   - Desmarcar → volta a mostrar todos
   - Combinar com Search e com paginação
   - Selecionar tudo, depois marcar "Official products" → ver o alerta
     amarelo informando quantos itens estão ocultos
2. Em `/training_set_maker`: mesmo comportamento, adaptado para seleção
   única (alerta avisa se o catálogo selecionado está oculto pelo filtro)
   
   
   
   <img width="1877" height="570" alt="image" src="https://github.com/user-attachments/assets/97406365-9d71-408e-be82-6793dc015333" />