### PR TITLE
597 suporte hats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
       with:
         packages: gcc python3-dev build-essential libpcre3 libpcre3-dev
         version: 1.0
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
         # Semantic version range syntax or exact version of a Python version
-        python-version: '3.10'
+        python-version: '3.11'
         # Optional - x64 or x86 architecture, defaults to x64
         architecture: 'x64'
     # You can test your matrix by printing the current Python version
@@ -35,4 +35,3 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # If this is set to a non-empty string, Python won’t try
 # to write .pyc files on the import of source modules

--- a/backend/core/file_utils.py
+++ b/backend/core/file_utils.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+MULTIPART_EXTENSIONS = (
+    ".tar.gz",
+    ".tar.bz2",
+    ".tar.xz",
+)
+
+
+def get_file_extension(filename: str) -> str:
+    """Return normalized file extension, preserving common multipart extensions."""
+    basename = Path(filename).name.lower()
+
+    for extension in MULTIPART_EXTENSIONS:
+        if basename.endswith(extension):
+            return extension
+
+    return Path(basename).suffix.lower()

--- a/backend/core/migrations/0059_productfile_is_directory.py
+++ b/backend/core/migrations/0059_productfile_is_directory.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0058_product_download_archive"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="productfile",
+            name="is_directory",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/core/models/product_file.py
+++ b/backend/core/models/product_file.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from core.models import Product
 from django.db import models
@@ -37,12 +38,18 @@ class ProductFile(models.Model):
     extension = models.CharField(
         verbose_name="Extension", max_length=10, null=True, blank=True
     )
+    is_directory = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True, blank=True)
     updated = models.DateTimeField(auto_now=True)
 
     def delete(self, *args, **kwargs):
         if self.file:
-            self.file.delete()
+            file_path = self.file.path
+            if os.path.isdir(file_path):
+                shutil.rmtree(file_path, ignore_errors=True)
+                self.file.name = None
+            else:
+                self.file.delete()
         super().delete(*args, **kwargs)
 
     def can_delete(self, user) -> bool:

--- a/backend/core/product_steps.py
+++ b/backend/core/product_steps.py
@@ -3,11 +3,13 @@ import pathlib
 import time
 from json import dumps, loads
 
+from core.file_utils import get_file_extension
 from core.models import Product, ProductContent, ProductFile
 from core.product_handle import NotTableError
 from core.serializers import ProductSerializer
 from core.table_data_collector import MainTableDataCollector
 from django.conf import settings
+from django.utils import timezone
 
 LOGGER = logging.getLogger("products")
 
@@ -197,6 +199,15 @@ class RegistryProduct:
         ".parquet",
         ".pq",
     }
+    TABULAR_MAIN_FILE_REQUIRED_PRODUCT_TYPES = {
+        "redshift_catalog",
+        "training_set",
+        "object_catalog",
+    }
+    NON_HATS_MULTI_FILE_ERROR_MESSAGE = (
+        "Please provide your data as a single table in one of the supported "
+        "formats of a HATS collection"
+    )
 
     def __init__(self, product_id):
         self.main_file = None
@@ -227,9 +238,15 @@ class RegistryProduct:
             mf = self.product.files.get(role=0)
             self.main_file = pathlib.Path(mf.file.path)
             LOGGER.debug("Main File: [%s]" % self.main_file)
+            self.replace_compressed_main_file_with_extracted_content(mf)
+            self.validate_main_file_business_rules()
 
             product_columns = list()
             table_data = None
+            requires_tabular_main_file = (
+                self.product.product_type.name
+                in self.TABULAR_MAIN_FILE_REQUIRED_PRODUCT_TYPES
+            )
             try:
                 # Faz uma única leitura dos dados tabulares para reutilizar
                 # preview, colunas e número de linhas no registro.
@@ -237,23 +254,33 @@ class RegistryProduct:
             except NotTableError as err:
                 LOGGER.warning(err)
                 self.remove_table_preview()
+                if requires_tabular_main_file:
+                    raise
+            except Exception as err:
+                LOGGER.warning(err)
+                self.remove_table_preview()
+                if requires_tabular_main_file:
+                    raise
 
             if table_data:
                 product_columns = table_data["columns"]
                 if table_data["n_rows"] is not None:
                     mf.n_rows = table_data["n_rows"]
-                    mf.save(update_fields=["n_rows", "updated"])
+                    ProductFile.objects.filter(pk=mf.pk).update(
+                        n_rows=table_data["n_rows"],
+                        updated=timezone.now(),
+                    )
                     LOGGER.debug("Number of rows: %s", str(mf.n_rows))
 
             # Verifica se o product type é redshift_catalog
             # Para esses produtos é mandatório ter acesso as colunas da tabela
             # Para os demais produtos é opicional.
-            if self.product.product_type.name == "redshift_catalog":
+            if requires_tabular_main_file:
                 if len(product_columns) == 0:
                     raise Exception(
                         (
                             "It was not possible to identify the product columns. "
-                            "For Redshift Catalogs this is mandatory. "
+                            "For Redshift Catalogs, Object Catalogs and Training Set this is mandatory. "
                             "Please check the file format."
                         )
                     )
@@ -274,10 +301,131 @@ class RegistryProduct:
             LOGGER.error(e)
             raise Exception(e)
 
+    def validate_main_file_business_rules(self):
+        """Apply product-type rules for supported main-file structures."""
+        product_type_name = self.product.product_type.name
+        if product_type_name not in self.TABULAR_MAIN_FILE_REQUIRED_PRODUCT_TYPES:
+            return
+
+        collector = MainTableDataCollector(
+            main_file=self._load_main_file(),
+            preview_rows=self.TABLE_PREVIEW_ROWS,
+            tabular_suffixes=self.TABULAR_SUFFIXES,
+        )
+
+        if not collector.is_compressed_main_file():
+            return
+
+        archive_info = collector.inspect_compressed_main_file()
+        if archive_info["is_hats"]:
+            return
+
+        if archive_info["file_count"] == 1 and archive_info["tabular_file_count"] == 1:
+            return
+
+        raise Exception(self.NON_HATS_MULTI_FILE_ERROR_MESSAGE)
+
+    def replace_compressed_main_file_with_extracted_content(self, main_file_record):
+        """Replace compressed main file with extracted supported content.
+
+        Replacement is performed only when compressed content maps to:
+        - a single tabular file; or
+        - a HATS collection layout.
+        """
+        collector = MainTableDataCollector(
+            main_file=self._load_main_file(),
+            preview_rows=self.TABLE_PREVIEW_ROWS,
+            tabular_suffixes=self.TABULAR_SUFFIXES,
+        )
+
+        if not collector.is_compressed_main_file():
+            return
+
+        product_dir = pathlib.Path(settings.MEDIA_ROOT, self.product.path)
+        archive_path = self._load_main_file()
+
+        try:
+            extraction = collector.extract_supported_main_content(product_dir)
+        except NotTableError:
+            return
+
+        extracted_path = pathlib.Path(extraction["path"]).resolve()
+        self._replace_main_file_record(
+            main_file_record,
+            extracted_path,
+            extraction["kind"],
+            extracted_size=extraction.get("size_bytes"),
+        )
+
+        if (
+            archive_path.exists()
+            and archive_path.is_file()
+            and archive_path != extracted_path
+        ):
+            archive_path.unlink(missing_ok=True)
+
+        self.main_file = extracted_path
+
+    def _replace_main_file_record(
+        self,
+        main_file_record,
+        extracted_path,
+        extracted_kind,
+        extracted_size=None,
+    ):
+        """Persist extracted main-file metadata back into ProductFile."""
+        media_root = pathlib.Path(settings.MEDIA_ROOT).resolve()
+        product_root = pathlib.Path(settings.MEDIA_ROOT, self.product.path).resolve()
+
+        relative_media_path = extracted_path.relative_to(media_root).as_posix()
+        relative_product_name = extracted_path.relative_to(product_root).as_posix()
+        extension = (
+            ".hats"
+            if extracted_kind == "hats"
+            else get_file_extension(extracted_path.name)
+        )
+
+        main_file_record.file.name = relative_media_path
+        main_file_record.name = relative_product_name
+        main_file_record.extension = extension
+        main_file_record.is_directory = extracted_kind == "hats"
+        main_file_record.size = (
+            int(extracted_size)
+            if extracted_size is not None
+            else self._path_size(extracted_path)
+        )
+        main_file_record.n_rows = None
+        main_file_record.save(
+            update_fields=[
+                "file",
+                "name",
+                "extension",
+                "is_directory",
+                "size",
+                "n_rows",
+                "updated",
+            ]
+        )
+
+    @staticmethod
+    def _path_size(path):
+        """Compute byte size for file or directory."""
+        path = pathlib.Path(path)
+        if path.is_file():
+            return path.stat().st_size
+
+        size = 0
+        for file_path in path.rglob("*"):
+            if file_path.is_file():
+                size += file_path.stat().st_size
+        return size
+
     @classmethod
     def get_table_preview_path(cls, product):
         """Build the absolute path to the cached table preview JSON file."""
-        return pathlib.Path(settings.MEDIA_ROOT, product.path, cls.TABLE_PREVIEW_FILENAME)
+        return pathlib.Path(
+            settings.MEDIA_ROOT, product.path, cls.TABLE_PREVIEW_FILENAME
+        )
 
     @classmethod
     def get_table_preview_processing_path(cls, product):

--- a/backend/core/serializers/product_file.py
+++ b/backend/core/serializers/product_file.py
@@ -22,6 +22,7 @@ class ProductFileSerializer(serializers.ModelSerializer):
             "size",
             "n_rows",
             "extension",
+            "is_directory",
         )
         fields = "__all__"
 

--- a/backend/core/table_data_collector.py
+++ b/backend/core/table_data_collector.py
@@ -1,4 +1,6 @@
+import logging
 import pathlib
+import shutil
 import tarfile
 import tempfile
 import zipfile
@@ -6,7 +8,10 @@ from gzip import open as gzip_open
 
 import pandas as pd
 import pyarrow.parquet as pq
+from core.file_utils import get_file_extension
 from core.product_handle import CsvHandle, FileHandle, NotTableError, ProductHandle, TxtHandle
+
+LOGGER = logging.getLogger("products")
 
 
 class MainTableDataCollector:
@@ -23,6 +28,7 @@ class MainTableDataCollector:
         self.main_file = pathlib.Path(main_file)
         self.preview_rows = preview_rows
         self.tabular_suffixes = tabular_suffixes
+        self._compressed_members_cache = None
 
     def collect(self):
         """Collect preview rows, column names, and total row count.
@@ -33,10 +39,376 @@ class MainTableDataCollector:
         Raises:
             NotTableError: If no tabular content can be extracted from the file.
         """
-        suffix = self.main_file.suffix.lower()
-        if suffix in {".zip", ".tar", ".gz"}:
+        if self.main_file.is_dir():
+            return self._collect_from_hats_directory(self.main_file)
+
+        if self._is_compressed_main_file():
             return self._collect_from_compressed_main_file()
         return self._collect_from_path(self.main_file)
+
+    def is_compressed_main_file(self):
+        """Public helper to check whether the main file is compressed."""
+        return self._is_compressed_main_file()
+
+    def inspect_compressed_main_file(self, members=None):
+        """Inspect compressed main file contents and classify supported structures.
+
+        Returns:
+            dict: Information about compressed members and classification:
+                - file_count (int)
+                - tabular_files (list[str])
+                - tabular_file_count (int)
+                - is_hats (bool)
+        """
+        if not self._is_compressed_main_file():
+            raise NotTableError("Main file is not compressed.")
+
+        members = members if members is not None else self._list_compressed_members()
+        tabular_files = [
+            str(member)
+            for member in members
+            if get_file_extension(member.name) in self.tabular_suffixes
+        ]
+
+        return {
+            "file_count": len(members),
+            "tabular_files": tabular_files,
+            "tabular_file_count": len(tabular_files),
+            "is_hats": self._is_hats_layout(members),
+        }
+
+    def extract_supported_main_content(self, destination_dir):
+        """Extract compressed content into destination directory when supported.
+
+        Supported extraction targets:
+        - Single tabular file inside the archive.
+        - HATS collection layout.
+
+        Args:
+            destination_dir (str | pathlib.Path): Product directory where extracted
+                content should be written.
+
+        Returns:
+            dict: Extraction details with keys:
+                - kind: "tabular" or "hats"
+                - path: pathlib.Path to extracted main file/directory
+                - file_count: number of files in compressed source
+                - tabular_file_count: number of detected tabular files
+                - is_hats: bool
+
+        Raises:
+            NotTableError: If compressed content does not match supported layouts.
+        """
+        if not self._is_compressed_main_file():
+            raise NotTableError("Main file is not compressed.")
+
+        members = self._list_compressed_members()
+        info = self.inspect_compressed_main_file(members=members)
+        destination_dir = pathlib.Path(destination_dir)
+        destination_dir.mkdir(parents=True, exist_ok=True)
+
+        if info["file_count"] == 1 and info["tabular_file_count"] == 1:
+            member_name = pathlib.PurePosixPath(info["tabular_files"][0])
+            extracted_path = self._extract_single_member(destination_dir, member_name)
+            return {
+                "kind": "tabular",
+                "path": extracted_path,
+                "file_count": info["file_count"],
+                "tabular_file_count": info["tabular_file_count"],
+                "is_hats": False,
+                "extracted_members": [extracted_path],
+                "size_bytes": extracted_path.stat().st_size,
+            }
+
+        staging_dir = pathlib.Path(
+            tempfile.mkdtemp(prefix=".__hats_extract_", dir=destination_dir)
+        )
+        try:
+            extracted_members = self._extract_all_members(staging_dir)
+            size_bytes = sum(
+                path.stat().st_size for path in extracted_members if path.exists()
+            )
+            hats_root = self._resolve_hats_root_from_members(staging_dir, members)
+            lsdb_hats = self._is_hats_with_lsdb(hats_root)
+
+            if lsdb_hats is False:
+                raise NotTableError(
+                    "Compressed main file does not map to a readable HATS collection."
+                )
+
+            if lsdb_hats is None and not info["is_hats"]:
+                raise NotTableError(
+                    "Compressed main file does not map to a single tabular file or a HATS collection."
+                )
+
+            final_hats_root = self._finalize_hats_extraction(
+                staging_dir=staging_dir,
+                hats_root=hats_root,
+                destination_dir=destination_dir,
+            )
+            return {
+                "kind": "hats",
+                "path": final_hats_root,
+                "file_count": info["file_count"],
+                "tabular_file_count": info["tabular_file_count"],
+                "is_hats": True,
+                "extracted_members": [final_hats_root],
+                "size_bytes": size_bytes,
+            }
+        finally:
+            if staging_dir.exists():
+                shutil.rmtree(staging_dir, ignore_errors=True)
+
+    def _is_compressed_main_file(self):
+        """Identify whether the main file should be handled as compressed."""
+        if self.main_file.is_dir():
+            return False
+
+        extension = get_file_extension(self.main_file.name)
+        if extension in {".gz", ".gzip"}:
+            return True
+
+        return zipfile.is_zipfile(self.main_file) or tarfile.is_tarfile(self.main_file)
+
+    def _list_compressed_members(self):
+        """List non-directory member paths in compressed file."""
+        if self._compressed_members_cache is not None:
+            return self._compressed_members_cache
+
+        if zipfile.is_zipfile(self.main_file):
+            with zipfile.ZipFile(self.main_file) as archive:
+                members = [
+                    pathlib.PurePosixPath(info.filename)
+                    for info in archive.infolist()
+                    if not info.is_dir()
+                ]
+                self._compressed_members_cache = members
+                return members
+
+        if tarfile.is_tarfile(self.main_file):
+            with tarfile.open(self.main_file, mode="r:*") as archive:
+                members = [
+                    pathlib.PurePosixPath(member.name)
+                    for member in archive.getmembers()
+                    if member.isfile()
+                ]
+                self._compressed_members_cache = members
+                return members
+
+        if get_file_extension(self.main_file.name) in {".gz", ".gzip"}:
+            inferred_member = pathlib.PurePosixPath(pathlib.Path(self.main_file.stem).name)
+            members = [inferred_member]
+            self._compressed_members_cache = members
+            return members
+
+        self._compressed_members_cache = []
+        return self._compressed_members_cache
+
+    def _extract_all_members(self, destination_dir):
+        """Extract all non-directory members into destination directory."""
+        destination_dir = pathlib.Path(destination_dir)
+        extracted_paths = []
+
+        if zipfile.is_zipfile(self.main_file):
+            with zipfile.ZipFile(self.main_file) as archive:
+                for info in archive.infolist():
+                    if info.is_dir():
+                        continue
+                    member_path = pathlib.PurePosixPath(info.filename)
+                    output_path = self._safe_member_destination(
+                        destination_dir, member_path
+                    )
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    with archive.open(info, "r") as source:
+                        output_path.write_bytes(source.read())
+                    extracted_paths.append(output_path)
+            return extracted_paths
+
+        if tarfile.is_tarfile(self.main_file):
+            with tarfile.open(self.main_file, mode="r:*") as archive:
+                for member in archive.getmembers():
+                    if not member.isfile():
+                        continue
+                    member_path = pathlib.PurePosixPath(member.name)
+                    output_path = self._safe_member_destination(
+                        destination_dir, member_path
+                    )
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    fileobj = archive.extractfile(member)
+                    if not fileobj:
+                        continue
+                    output_path.write_bytes(fileobj.read())
+                    extracted_paths.append(output_path)
+            return extracted_paths
+
+        if get_file_extension(self.main_file.name) in {".gz", ".gzip"}:
+            inferred_member = pathlib.PurePosixPath(pathlib.Path(self.main_file.stem).name)
+            output_path = self._safe_member_destination(destination_dir, inferred_member)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with gzip_open(self.main_file, "rb") as source:
+                output_path.write_bytes(source.read())
+            return [output_path]
+
+        raise NotTableError("Compressed extraction is not supported for this file.")
+
+    def _extract_single_member(self, destination_dir, member_name):
+        """Extract one named member into destination directory."""
+        destination_dir = pathlib.Path(destination_dir)
+        member_name = pathlib.PurePosixPath(member_name)
+
+        if zipfile.is_zipfile(self.main_file):
+            with zipfile.ZipFile(self.main_file) as archive:
+                for info in archive.infolist():
+                    if info.is_dir():
+                        continue
+                    candidate = pathlib.PurePosixPath(info.filename)
+                    if candidate != member_name:
+                        continue
+                    output_path = self._safe_member_destination(
+                        destination_dir, member_name
+                    )
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    with archive.open(info, "r") as source:
+                        output_path.write_bytes(source.read())
+                    return output_path
+            raise NotTableError("Tabular member not found in zip archive.")
+
+        if tarfile.is_tarfile(self.main_file):
+            with tarfile.open(self.main_file, mode="r:*") as archive:
+                for member in archive.getmembers():
+                    if not member.isfile():
+                        continue
+                    candidate = pathlib.PurePosixPath(member.name)
+                    if candidate != member_name:
+                        continue
+                    output_path = self._safe_member_destination(
+                        destination_dir, member_name
+                    )
+                    output_path.parent.mkdir(parents=True, exist_ok=True)
+                    fileobj = archive.extractfile(member)
+                    if not fileobj:
+                        continue
+                    output_path.write_bytes(fileobj.read())
+                    return output_path
+            raise NotTableError("Tabular member not found in tar archive.")
+
+        if get_file_extension(self.main_file.name) in {".gz", ".gzip"}:
+            output_path = self._safe_member_destination(destination_dir, member_name)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with gzip_open(self.main_file, "rb") as source:
+                output_path.write_bytes(source.read())
+            return output_path
+
+        raise NotTableError("Compressed extraction is not supported for this file.")
+
+    def _resolve_hats_root_from_members(self, destination_dir, members):
+        """Resolve HATS root directory after extraction using hats.properties path."""
+        destination_dir = pathlib.Path(destination_dir)
+        hats_member = next(
+            (m for m in members if m.name in self.HATS_PROPERTIES_FILENAMES),
+            None,
+        )
+        if hats_member is None:
+            return destination_dir
+
+        parent = pathlib.Path(*hats_member.parts[:-1]) if hats_member.parts[:-1] else pathlib.Path(".")
+        hats_root = (destination_dir / parent).resolve()
+        return hats_root
+
+    def _is_hats_with_lsdb(self, hats_root):
+        """Validate HATS by attempting to open it with LSDB.
+
+        Returns:
+            bool | None:
+                - True when LSDB confirms catalog readability.
+                - False when LSDB is available but cannot open the path.
+                - None when LSDB is not available in this environment.
+        """
+        try:
+            import lsdb  # type: ignore
+        except Exception:
+            LOGGER.debug("LSDB is not available; falling back to layout heuristic.")
+            return None
+
+        try:
+            catalog = lsdb.open_catalog(path=str(hats_root))
+            _ = getattr(catalog, "columns", None)
+            return True
+        except Exception as error:
+            LOGGER.debug("LSDB could not open HATS path %s: %s", hats_root, error)
+            return False
+
+    def _finalize_hats_extraction(self, staging_dir, hats_root, destination_dir):
+        """Move validated extracted HATS directory from staging into destination."""
+        staging_dir = pathlib.Path(staging_dir).resolve()
+        hats_root = pathlib.Path(hats_root).resolve()
+        destination_dir = pathlib.Path(destination_dir).resolve()
+
+        if hats_root == staging_dir:
+            final_root = destination_dir / f"{self.main_file.stem}_hats"
+            if final_root.exists():
+                shutil.rmtree(final_root, ignore_errors=True)
+            shutil.move(str(staging_dir), str(final_root))
+            return final_root
+
+        if staging_dir not in hats_root.parents:
+            raise NotTableError("Invalid HATS extraction root.")
+
+        relative = hats_root.relative_to(staging_dir)
+        final_root = destination_dir / relative
+        if final_root.exists():
+            if final_root.is_dir():
+                shutil.rmtree(final_root, ignore_errors=True)
+            else:
+                final_root.unlink(missing_ok=True)
+        final_root.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(hats_root), str(final_root))
+        return final_root
+
+    def _safe_member_destination(self, destination_dir, member_path):
+        """Build a safe destination path for an archive member."""
+        destination_dir = pathlib.Path(destination_dir).resolve()
+        relative_parts = [part for part in pathlib.PurePosixPath(member_path).parts if part not in ("", ".")]
+        if any(part == ".." for part in relative_parts):
+            raise NotTableError(f"Unsafe member path in archive: {member_path}")
+
+        output_path = destination_dir.joinpath(*relative_parts).resolve()
+        if destination_dir not in output_path.parents and output_path != destination_dir:
+            raise NotTableError(f"Unsafe member path in archive: {member_path}")
+
+        return output_path
+
+    def _is_hats_layout(self, members):
+        """Infer whether compressed members look like a HATS catalog layout."""
+        if not members:
+            return False
+
+        # Remove leading '.' or wrapper directories for easier matching.
+        normalized_members = [pathlib.PurePosixPath(str(m).lstrip("./")) for m in members]
+
+        has_hats_properties = any(
+            member.name in self.HATS_PROPERTIES_FILENAMES
+            for member in normalized_members
+        )
+
+        has_dataset_parquet = False
+        has_norder_npix_parquet = False
+
+        for member in normalized_members:
+            extension = get_file_extension(member.name)
+            if extension not in {".parquet", ".pq"}:
+                continue
+
+            parts = member.parts
+            if "dataset" in parts:
+                has_dataset_parquet = True
+
+            has_norder = any(part.startswith("Norder=") for part in parts)
+            has_npix = any(part.startswith("Npix=") for part in parts)
+            if has_norder and has_npix:
+                has_norder_npix_parquet = True
+
+        return has_hats_properties and (has_dataset_parquet or has_norder_npix_parquet)
 
     def _collect_from_path(self, filepath):
         """Collect tabular metadata from a regular file path.
@@ -97,6 +469,99 @@ class MainTableDataCollector:
             "columns": list(df_full.columns),
             "n_rows": int(len(df_full)),
         }
+
+    def _collect_from_hats_directory(self, hats_root):
+        """Collect metadata from a HATS directory using LSDB."""
+        hats_root = pathlib.Path(hats_root)
+        if not hats_root.is_dir():
+            raise NotTableError("HATS root is not a directory.")
+
+        try:
+            import lsdb  # type: ignore
+        except Exception as error:
+            raise NotTableError(
+                "LSDB dependency is required to preview HATS collections."
+            ) from error
+
+        try:
+            catalog = lsdb.open_catalog(path=str(hats_root))
+        except Exception as error:
+            raise NotTableError(
+                f"Could not open HATS collection with LSDB: {error}"
+            ) from error
+
+        columns = self._normalize_catalog_columns(getattr(catalog, "columns", None))
+        if not columns:
+            columns = self._normalize_catalog_columns(
+                getattr(catalog, "all_columns", None)
+            )
+
+        preview_obj = catalog.head(self.preview_rows)
+        preview_df = self._coerce_lsdb_preview_to_dataframe(preview_obj, columns)
+        n_rows = self._estimate_lsdb_row_count(catalog)
+
+        return {
+            "preview_df": preview_df,
+            "columns": list(preview_df.columns) if not columns else columns,
+            "n_rows": n_rows,
+        }
+
+    def _normalize_catalog_columns(self, value):
+        """Normalize LSDB catalog column-like values to a plain list of strings."""
+        if value is None:
+            return []
+
+        if isinstance(value, pd.Index):
+            return [str(col) for col in value.tolist()]
+
+        if isinstance(value, (list, tuple, set)):
+            return [str(col) for col in value]
+
+        try:
+            as_list = list(value)
+            return [str(col) for col in as_list]
+        except Exception:
+            return []
+
+    def _coerce_lsdb_preview_to_dataframe(self, preview_obj, fallback_columns):
+        """Convert LSDB head result to pandas DataFrame."""
+        if preview_obj is None:
+            return pd.DataFrame(columns=fallback_columns)
+
+        if isinstance(preview_obj, pd.DataFrame):
+            return preview_obj.reset_index(drop=True)
+
+        if hasattr(preview_obj, "to_pandas"):
+            try:
+                df = preview_obj.to_pandas()
+                if isinstance(df, pd.DataFrame):
+                    return df.reset_index(drop=True)
+            except Exception:
+                pass
+
+        if hasattr(preview_obj, "compute"):
+            computed = preview_obj.compute()
+            if isinstance(computed, pd.DataFrame):
+                return computed.reset_index(drop=True)
+            try:
+                return pd.DataFrame(computed).reset_index(drop=True)
+            except Exception:
+                pass
+
+        try:
+            return pd.DataFrame(preview_obj).reset_index(drop=True)
+        except Exception as error:
+            raise NotTableError(
+                f"Could not materialize LSDB preview rows as DataFrame: {error}"
+            ) from error
+
+    def _estimate_lsdb_row_count(self, catalog):
+        """Estimate LSDB row count, preferring metadata-only methods when available."""
+        try:
+            # LSDB exposes lazy metadata-backed length for catalogs.
+            return int(len(catalog))
+        except Exception:
+            return None
 
     def _collect_from_parquet(self, filepath):
         """Collect metadata from parquet using incremental batch reads.
@@ -184,13 +649,13 @@ class MainTableDataCollector:
         Raises:
             NotTableError: If the compressed file type is unsupported or has no tabular member.
         """
-        suffix = self.main_file.suffix.lower()
+        extension = get_file_extension(self.main_file.name)
 
-        if suffix == ".zip":
+        if zipfile.is_zipfile(self.main_file):
             extracted_path = self._extract_tabular_from_zip()
-        elif suffix in {".tar", ".gz"} and tarfile.is_tarfile(self.main_file):
+        elif tarfile.is_tarfile(self.main_file):
             extracted_path = self._extract_tabular_from_tar()
-        elif suffix == ".gz":
+        elif extension in {".gz", ".gzip"}:
             extracted_path = self._extract_tabular_from_gzip_single()
         else:
             raise NotTableError("Compressed table preview is not supported for this file.")
@@ -231,7 +696,7 @@ class MainTableDataCollector:
         Raises:
             NotTableError: If no supported tabular file exists in the archive.
         """
-        with tarfile.open(self.main_file) as archive:
+        with tarfile.open(self.main_file, mode="r:*") as archive:
             for member in archive.getmembers():
                 if not member.isfile():
                     continue
@@ -272,3 +737,4 @@ class MainTableDataCollector:
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
             tmp.write(content)
             return pathlib.Path(tmp.name)
+    HATS_PROPERTIES_FILENAMES = {"hats.properties", "properties"}

--- a/backend/core/test/test_file_utils.py
+++ b/backend/core/test/test_file_utils.py
@@ -1,0 +1,13 @@
+from core.file_utils import get_file_extension
+
+
+def test_get_file_extension_for_simple_extension():
+    assert get_file_extension("catalog.csv") == ".csv"
+
+
+def test_get_file_extension_for_multipart_extension():
+    assert get_file_extension("catalog.tar.gz") == ".tar.gz"
+
+
+def test_get_file_extension_is_case_insensitive():
+    assert get_file_extension("CATALOG.TAR.GZ") == ".tar.gz"

--- a/backend/core/test/test_product_file.py
+++ b/backend/core/test/test_product_file.py
@@ -1,8 +1,8 @@
 import json
 import mimetypes
-import os
 from pathlib import Path
 
+from core.file_utils import get_file_extension
 from core.models import Product, ProductFile, ProductType, Release, FileRoles
 from core.serializers import ProductFileSerializer
 from core.test.util import sample_product_file
@@ -214,12 +214,11 @@ class ProductFileDetailAPIViewTestCase(APITestCase):
             "role": self.product_file.role,
             "role_name": serializer_data["role_name"],
             "name": self.product_file.name,
-            "type": mimetypes.guess_type(os.path.basename(self.product_file.file.name))[
-                0
-            ],
+            "type": mimetypes.guess_type(Path(self.product_file.file.name).name)[0],
             "size": self.product_file.file.size,
             "n_rows": None,
-            "extension": os.path.splitext(self.product_file.file.name)[1],
+            "extension": get_file_extension(self.product_file.file.name),
+            "is_directory": False,
             "created": self.product_file.created.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "updated": self.product_file.updated.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "can_delete": True,

--- a/backend/core/test/test_product_registry.py
+++ b/backend/core/test/test_product_registry.py
@@ -1,11 +1,18 @@
 import json
 import mimetypes
+import sys
+import tarfile
+import tempfile
+import types
+import zipfile
 from pathlib import Path
 from unittest import mock
 
+import pandas as pd
 from core.models import Product, ProductFile, ProductType, Release
 from core.product_handle import ProductHandle
 from core.product_steps import RegistryProduct
+from core.table_data_collector import MainTableDataCollector
 from core.test.util import sample_product_file
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -32,16 +39,19 @@ class ProductRegistryTestCase(APITestCase):
 
         # Get Product Types previous created by fixtures
         self.redshift_catalogs = ProductType.objects.get(name="redshift_catalog")
+        self.training_set = ProductType.objects.get(name="training_set")
 
         self.validation_results = ProductType.objects.get(name="validation_results")
 
-    def create_product(self, specz=False):
-
+    def create_product(self, specz=False, product_type_name=None):
         product_type = self.validation_results.pk
         release = self.release.pk
-        if specz == True:
+
+        if product_type_name == "redshift_catalog" or specz is True:
             product_type = self.redshift_catalogs.pk
             release = None
+        elif product_type_name == "training_set":
+            product_type = self.training_set.pk
 
         # Make request
         url = reverse("products-list")
@@ -86,6 +96,83 @@ class ProductRegistryTestCase(APITestCase):
 
         return ProductFile.objects.get(pk=data["id"])
 
+    def upload_main_file_from_path(self, product, filepath):
+        with open(filepath, "rb") as fp:
+            mime_type = mimetypes.guess_type(filepath)[0] or "application/octet-stream"
+            response = self.client.post(
+                reverse("product_files-list"),
+                dict(
+                    {
+                        "product": product.pk,
+                        "file": fp,
+                        "role": 0,
+                        "type": mime_type,
+                    }
+                ),
+                format="multipart",
+            )
+        data = json.loads(response.content)
+        return ProductFile.objects.get(pk=data["id"])
+
+    def create_multi_file_archive(self, extension="zip"):
+        temp_dir = Path(tempfile.mkdtemp(prefix="pz_multi_archive_"))
+        file_a = temp_dir / "notes_a.txt"
+        file_b = temp_dir / "notes_b.txt"
+        file_a.write_text("alpha", encoding="utf-8")
+        file_b.write_text("beta", encoding="utf-8")
+
+        if extension == "zip":
+            archive_path = temp_dir / "multi.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.write(file_a, arcname=file_a.name)
+                archive.write(file_b, arcname=file_b.name)
+            return archive_path
+
+        archive_path = temp_dir / "multi.tar"
+        with tarfile.open(archive_path, "w") as archive:
+            archive.add(file_a, arcname=file_a.name)
+            archive.add(file_b, arcname=file_b.name)
+        return archive_path
+
+    def create_fake_hats_archive(self, properties_filename="hats.properties"):
+        temp_dir = Path(tempfile.mkdtemp(prefix="pz_hats_archive_"))
+        hats_root = temp_dir / "mock_hats"
+        dataset_dir = hats_root / "dataset" / "Norder=0" / "Npix=0"
+        dataset_dir.mkdir(parents=True, exist_ok=True)
+
+        (hats_root / properties_filename).write_text(
+            "catalog_name=mock_hats\n",
+            encoding="utf-8",
+        )
+        (dataset_dir / "part-0.parquet").write_text("", encoding="utf-8")
+
+        archive_path = temp_dir / "mock_hats.zip"
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            for file_path in hats_root.rglob("*"):
+                if file_path.is_file():
+                    arcname = file_path.relative_to(temp_dir).as_posix()
+                    archive.write(file_path, arcname=arcname)
+        return archive_path
+
+    def create_fake_lsdb_module(self, n_rows=12, columns_as_index=False):
+        class FakeCatalog:
+            columns = pd.Index(["ra", "dec", "z"]) if columns_as_index else ["ra", "dec", "z"]
+            all_columns = ["ra", "dec", "z"]
+
+            def __len__(self):
+                return n_rows
+
+            def head(self, n=5):
+                rows = [
+                    {"ra": float(i), "dec": float(i) * -1.0, "z": float(i) * 0.1}
+                    for i in range(n_rows)
+                ]
+                return pd.DataFrame(rows).head(n)
+
+        fake_module = types.ModuleType("lsdb")
+        fake_module.open_catalog = mock.Mock(return_value=FakeCatalog())
+        return fake_module
+
     def test_product_registry(self):
         product = self.create_product()
         self.upload_main_file(product, "csv")
@@ -119,6 +206,177 @@ class ProductRegistryTestCase(APITestCase):
             settings.MEDIA_ROOT, product.path, RegistryProduct.TABLE_PREVIEW_FILENAME
         )
         self.assertTrue(preview_path.exists())
+
+        main_file = ProductFile.objects.get(product=product, role=0)
+        self.assertTrue(main_file.name.endswith(".csv"))
+        self.assertEqual(main_file.extension, ".csv")
+        self.assertFalse(main_file.is_directory)
+        self.assertFalse(Path(main_file.file.path).name.endswith(".zip"))
+
+    def test_registry_tgz_file(self):
+        product = self.create_product()
+        self.upload_main_file(product, extension="csv", compression="tgz", header=True)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
+        preview_path = Path(
+            settings.MEDIA_ROOT, product.path, RegistryProduct.TABLE_PREVIEW_FILENAME
+        )
+        self.assertTrue(preview_path.exists())
+
+    def test_registry_rejects_non_hats_multi_file_archive_for_training_set(self):
+        product = self.create_product(product_type_name="training_set")
+        archive_path = self.create_multi_file_archive(extension="zip")
+        self.upload_main_file_from_path(product, archive_path)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 500)
+        payload = json.loads(response.content)
+        self.assertEqual(
+            payload["error"],
+            RegistryProduct.NON_HATS_MULTI_FILE_ERROR_MESSAGE,
+        )
+
+    def test_registry_rejects_non_hats_multi_file_archive_for_redshift_catalog(self):
+        product = self.create_product(product_type_name="redshift_catalog")
+        archive_path = self.create_multi_file_archive(extension="tar")
+        self.upload_main_file_from_path(product, archive_path)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 500)
+        payload = json.loads(response.content)
+        self.assertEqual(
+            payload["error"],
+            RegistryProduct.NON_HATS_MULTI_FILE_ERROR_MESSAGE,
+        )
+
+    def test_registry_allows_multi_file_archive_for_validation_results(self):
+        product = self.create_product(product_type_name="validation_results")
+        archive_path = self.create_multi_file_archive(extension="zip")
+        self.upload_main_file_from_path(product, archive_path)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_registry_replaces_hats_archive_with_directory_main_file(self):
+        product = self.create_product(product_type_name="validation_results")
+        archive_path = self.create_fake_hats_archive()
+        uploaded_main = self.upload_main_file_from_path(product, archive_path)
+        original_archive_path = Path(uploaded_main.file.path)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+
+        with mock.patch.object(
+            MainTableDataCollector,
+            "_is_hats_with_lsdb",
+            autospec=True,
+            return_value=True,
+        ):
+            response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+
+        main_file = ProductFile.objects.get(product=product, role=0)
+        extracted_main_path = Path(main_file.file.path)
+        self.assertTrue(extracted_main_path.is_dir())
+        self.assertEqual(main_file.extension, ".hats")
+        self.assertTrue(main_file.is_directory)
+        self.assertTrue((extracted_main_path / "hats.properties").exists())
+        self.assertFalse(original_archive_path.exists())
+
+    def test_registry_uses_lsdb_probe_for_hats_detection(self):
+        product = self.create_product(product_type_name="validation_results")
+        archive_path = self.create_fake_hats_archive()
+        self.upload_main_file_from_path(product, archive_path)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+
+        with mock.patch.object(
+            MainTableDataCollector,
+            "_is_hats_with_lsdb",
+            autospec=True,
+            return_value=True,
+        ) as lsdb_probe_mock:
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertGreaterEqual(lsdb_probe_mock.call_count, 1)
+
+    def test_registry_accepts_legacy_hats_properties_filename(self):
+        product = self.create_product(product_type_name="training_set")
+        archive_path = self.create_fake_hats_archive(properties_filename="properties")
+        self.upload_main_file_from_path(product, archive_path)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+        fake_lsdb = self.create_fake_lsdb_module(n_rows=12)
+
+        with mock.patch.dict(sys.modules, {"lsdb": fake_lsdb}):
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
+        main_file = ProductFile.objects.get(product=product, role=0)
+        self.assertEqual(main_file.extension, ".hats")
+        self.assertTrue(main_file.is_directory)
+        self.assertTrue(Path(main_file.file.path).is_dir())
+
+    def test_registry_creates_hats_preview_and_metadata_with_lsdb(self):
+        product = self.create_product(product_type_name="validation_results")
+        archive_path = self.create_fake_hats_archive()
+        self.upload_main_file_from_path(product, archive_path)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+        fake_lsdb = self.create_fake_lsdb_module(n_rows=12)
+
+        with mock.patch.dict(sys.modules, {"lsdb": fake_lsdb}):
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
+        preview_path = Path(
+            settings.MEDIA_ROOT, product.path, RegistryProduct.TABLE_PREVIEW_FILENAME
+        )
+        self.assertTrue(preview_path.exists())
+
+        payload = json.loads(preview_path.read_text(encoding="utf-8"))
+        self.assertEqual(payload["count"], 10)
+        self.assertEqual(payload["columns"], ["ra", "dec", "z"])
+        self.assertEqual(len(payload["results"]), 10)
+
+        main_file = ProductFile.objects.get(product=product, role=0)
+        self.assertEqual(main_file.n_rows, 12)
+        self.assertEqual(main_file.extension, ".hats")
+        self.assertTrue(main_file.is_directory)
+        self.assertTrue(Path(main_file.file.path).is_dir())
+
+    def test_read_data_returns_cached_hats_preview(self):
+        product = self.create_product(product_type_name="validation_results")
+        archive_path = self.create_fake_hats_archive()
+        self.upload_main_file_from_path(product, archive_path)
+        fake_lsdb = self.create_fake_lsdb_module(n_rows=12)
+
+        with mock.patch.dict(sys.modules, {"lsdb": fake_lsdb}):
+            self.client.post(reverse("products-registry", kwargs={"pk": product.pk}))
+
+        response = self.client.get(
+            reverse("products-read-data", kwargs={"pk": product.pk}),
+            {"page": 1, "page_size": 10},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertEqual(data["count"], 10)
+        self.assertEqual(data["columns"], ["ra", "dec", "z"])
+        self.assertEqual(len(data["results"]), 10)
+
+    def test_registry_handles_lsdb_columns_as_pandas_index(self):
+        product = self.create_product(product_type_name="validation_results")
+        archive_path = self.create_fake_hats_archive()
+        self.upload_main_file_from_path(product, archive_path)
+        url = reverse("products-registry", kwargs={"pk": product.pk})
+        fake_lsdb = self.create_fake_lsdb_module(n_rows=12, columns_as_index=True)
+
+        with mock.patch.dict(sys.modules, {"lsdb": fake_lsdb}):
+            response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
 
     def test_registry_without_columns(self):
 

--- a/backend/core/test/util.py
+++ b/backend/core/test/util.py
@@ -157,10 +157,16 @@ def sample_product_file(
         with zipfile.ZipFile(result, mode="w") as archive:
             archive.write(filepath)
 
-    elif compression in ["tar", "gz"]:
-        filename = "sample_file.tar.gz" if compression == "gz" else "sample_file.tar"
+    elif compression in ["tar", "gz", "tgz"]:
+        if compression == "gz":
+            filename = "sample_file.tar.gz"
+        elif compression == "tgz":
+            filename = "sample_file.tgz"
+        else:
+            filename = "sample_file.tar"
         result = Path("/tmp/", filename)
-        with tarfile.open(result, "w:gz") as tar:
+        mode = "w" if compression == "tar" else "w:gz"
+        with tarfile.open(result, mode) as tar:
             tar.add(filepath)
 
     return result

--- a/backend/core/views/product.py
+++ b/backend/core/views/product.py
@@ -473,6 +473,17 @@ class ProductViewSet(AccessControlMixin, viewsets.ModelViewSet):
                 settings.MEDIA_ROOT, product.path, main_file_path
             )
 
+            if product_path.is_dir():
+                return Response(
+                    {
+                        "error": (
+                            "Main file is a directory-based dataset. "
+                            "Please use the full product download endpoint."
+                        )
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
             # Abre o arquivo e envia em bites para o navegador
             mimetype, _ = mimetypes.guess_type(product_path)
             size = product_path.stat().st_size

--- a/backend/core/views/product_file.py
+++ b/backend/core/views/product_file.py
@@ -1,6 +1,6 @@
 import logging
-import os
 
+from core.file_utils import get_file_extension
 from core.models import Product, ProductFile
 from core.serializers import ProductFileSerializer
 from rest_framework import exceptions, mixins, status, viewsets
@@ -48,12 +48,13 @@ class ProductFileViewSet(
 
         file = self.request.data.get("file")
         size = file.size
-        filename, extension = os.path.splitext(file.name)
+        extension = get_file_extension(file.name)
 
         return serializer.save(
             size=size,
             name=file.name,
             extension=extension,
+            is_directory=False,
         )
 
     def destroy(self, request, pk=None, *args, **kwargs):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-astropy==6.1.3
+astropy==7.1.1
 celery==5.4.0
 coverage==7.6.1
 Django==5.1.15
@@ -15,8 +15,9 @@ drf-social-oauth2==3.1.0
 drf-spectacular==0.27.2
 gunicorn==23.0.0
 h5py==3.11.0
-numpy==2.1.1
-pandas==2.2.2
+lsdb==0.9.0
+numpy==2.3.0
+pandas==2.2.3
 psycopg2-binary==2.9.9
 pyarrow==17.0.0
 pydantic==2.9.2

--- a/frontend/components/ProductDetail.js
+++ b/frontend/components/ProductDetail.js
@@ -194,7 +194,13 @@ export default function ProductDetail({ productId, internalName }) {
         setActiveTab(hasHtmlFile ? 1 : 0)
 
         const isTabularData = res.results.some(file => {
-          const lowerName = file.name.toLowerCase()
+          const lowerName = (file.name || '').toLowerCase()
+          const lowerExtension = (file.extension || '').toLowerCase()
+
+          if (file.is_directory || lowerExtension === '.hats') {
+            return true
+          }
+
           return (
             lowerName.endsWith('.csv') ||
             lowerName.endsWith('.xls') ||
@@ -208,19 +214,20 @@ export default function ProductDetail({ productId, internalName }) {
             lowerName.endsWith('.hdf5') ||
             lowerName.endsWith('.pq') ||
             lowerName.endsWith('.parq') ||
-            lowerName.endsWith('.parquet')
+            lowerName.endsWith('.parquet') ||
+            lowerExtension === '.csv' ||
+            lowerExtension === '.txt' ||
+            lowerExtension === '.fit' ||
+            lowerExtension === '.fits' ||
+            lowerExtension === '.h5' ||
+            lowerExtension === '.hf5' ||
+            lowerExtension === '.hdf' ||
+            lowerExtension === '.hdf5' ||
+            lowerExtension === '.pq' ||
+            lowerExtension === '.parq' ||
+            lowerExtension === '.parquet'
           )
         })
-
-        if (
-          ['other', 'photoz_estimates', 'validation_results'].includes(
-            product.product_type_internal_name
-          )
-        ) {
-          // If the product type is 'other', 'photoz_estimates', or 'validation_results' we don't load files
-          setIsTabular(false)
-          return
-        }
 
         setIsTabular(isTabularData)
 


### PR DESCRIPTION
## Contexto

Este PR adiciona suporte a **HATS** e a **arquivo tabular compactado** no upload, mantendo o fluxo atual de registro.

Também corrige a exibição do preview no frontend para qualquer produto com dado tabular válido.

---

## Implementações principais

### Backend
- Suporte a upload de arquivo compactado (`.zip`, `.tar`, `.gz`) como main file.
- Após descompactar, o conteúdo é tratado como:
  - **HATS** (aceito), ou
  - **arquivo tabular único** (aceito), ou
  - **múltiplos arquivos não-HATS** (rejeitado para `object_catalog`, `redshift_catalog` e `training_set`).
- Validação de HATS por tentativa real de leitura com `lsdb`.
- Substituição do arquivo compactado:
  - por arquivo tabular extraído (quando há 1 tabular),
  - por diretório HATS extraído (quando é HATS).
- Preview de 10 linhas integrado ao fluxo existente, incluindo HATS.
- Atualização de runtime/dependências para suportar `lsdb==0.9.0` (Python 3.11 + libs compatíveis).

### Frontend
- Ajuste de detecção de tabular para considerar `file.extension` e `file.is_directory` (caso HATS).
- Remoção de bloqueio por `product_type` que impedia preview em casos tabulares válidos.

---

## Fluxo final (HATS + compactado)

1. Usuário faz upload do main file (normal ou compactado).  
2. Se for compactado:
   - se tiver **1 tabular**, aceita;
   - se for **HATS**, aceita;
   - se for multi-arquivo não-HATS e tipo for `redshift_catalog`/`training_set`, rejeita com mensagem de validação.
3. O compactado é substituído pelo conteúdo extraído (arquivo tabular ou diretório HATS).
4. O backend gera preview (`__table_preview.json`) com 10 linhas, colunas e `n_rows`.
5. O frontend exibe **Table Preview** quando há dado tabular válido.

---

## O que preparar no ambiente para testar

### 1) Atualizar branch e rebuild
```bash
git pull
docker compose build backend pzworker pzbeat
docker compose up -d
```

### 2) Garantir migrações
```bash
docker compose exec backend python manage.py migrate
```

### 3) Cenários de teste recomendados
- Upload de .zip/.tar/.gz com um único arquivo tabular.
- Upload de .zip/.tar com coleção HATS.
- Upload de multi-arquivo não-HATS para training_set e redshift_catalog (deve falhar com mensagem de validação).

